### PR TITLE
feat: #31: Implement Field composition algebra (field-synthesis)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,14 @@ Create relevent github PR first, then create branch with {created issue number}-
 
 The format of PR title: same as Commit message format with adding a prefix: `PR:`
 
+## Code
+
+Do not generate unnecessary code
+
+Focus on the accurated essentials.
+
+Code as pessimistically and critically as possible.
+
 ## Git
 
 Commit message format: if it's working in a PR branch (skip in main branch). follow the format `{category (e.g. feat, docs, etc)}: #{issue number}: {message or short description}`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AI Agent Instructions
 
+All code or text content, output or comments must be written in English.
+
 ## Markdown format
 
 Do not use `---` between paragraphs. A horizontal rule is allowed only directly before the final reference or license section.
@@ -9,10 +11,6 @@ Minimize bold (`**`). Only apply it when absolutely necessary to highlight the s
 Minimize use `—` as much as possible except only when absolutely necessary.
 
 Do not prefix headings with numbers: Use plain headings.
-
-## Code
-
-All code and comments must be written in English.
 
 ## Content
 
@@ -24,10 +22,10 @@ Don't use sequential "Week 1, Week 2" enumerations. Use numbered experiments, ph
 
 Create relevent github PR first, then create branch with {created issue number}-{subject alphabets with one or two `-`} when start a new task subject.
 
+The format of PR title: same as Commit message format with adding a prefix: `PR:`
+
 ## Git
 
-When create a commit if it's working in a PR branch (skip in main branch). follow the format `{category (e.g. feat, docs, etc)}: #{issue number}: {message or short description}`
+Commit message format: if it's working in a PR branch (skip in main branch). follow the format `{category (e.g. feat, docs, etc)}: #{issue number}: {message or short description}`
 
 Do not test with github push.
-
-Always create a GPG commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,9 @@ Don't directly write `.ss`: use technical naming in the context of the sentence.
 
 Don't use sequential "Week 1, Week 2" enumerations. Use numbered experiments, phases, or milestones instead.
 
-## Task
+## Repository interaction
+
+Always use English
 
 Create relevent github PR first, then create branch with {created issue number}-{subject alphabets with one or two `-`} when start a new task subject.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Don't directly write `.ss`: use technical naming in the context of the sentence.
 
 Don't use sequential "Week 1, Week 2" enumerations. Use numbered experiments, phases, or milestones instead.
 
-## Repository interaction
+## Git
 
 Always use English
 
@@ -26,16 +26,16 @@ Create relevent github PR first, then create branch with {created issue number}-
 
 The format of PR title: same as Commit message format with adding a prefix: `PR:`
 
-## Code
-
-Do not generate unnecessary code
-
-Focus on the accurated essentials.
-
-Code as pessimistically and critically as possible.
-
-## Git
+Do not push without permission.
 
 Commit message format: if it's working in a PR branch (skip in main branch). follow the format `{category (e.g. feat, docs, etc)}: #{issue number}: {message or short description}`
 
 Do not test with github push.
+
+## Code
+
+Focus on the accurancy of the goal.
+
+Do not generate unnecessary code unless it was essential for the goal.
+
+Code as pessimistically and critically as possible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,13 @@ Don't use sequential "Week 1, Week 2" enumerations. Use numbered experiments, ph
 
 ## Git
 
+Do not push without permission.
+
 Always use English
 
 Create relevent github PR first, then create branch with {created issue number}-{subject alphabets with one or two `-`} when start a new task subject.
 
 The format of PR title: same as Commit message format with adding a prefix: `PR:`
-
-Do not push without permission.
 
 Commit message format: if it's working in a PR branch (skip in main branch). follow the format `{category (e.g. feat, docs, etc)}: #{issue number}: {message or short description}`
 

--- a/poc/standard/Cargo.lock
+++ b/poc/standard/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "hex",
  "serde",
  "ssccs-core",
+ "ssccs-examples",
  "ssccs-primitive",
  "thiserror",
 ]

--- a/poc/standard/crates/field-synthesis/Cargo.toml
+++ b/poc/standard/crates/field-synthesis/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 ssccs-core = { path = "../core" }
+ssccs-examples = { path = "../examples" }
 ssccs-primitive = { path = "../primitive", optional = true }
 blake3 = { workspace = true }
 hex = { workspace = true }

--- a/poc/standard/crates/field-synthesis/src/lib.rs
+++ b/poc/standard/crates/field-synthesis/src/lib.rs
@@ -199,10 +199,14 @@ impl ComposedField {
                 merged
             }
             CompositionOp::Intersection => {
-                let left: HashSet<SpaceCoordinates> =
-                    self.transition_expr(&self.left, coords).into_iter().collect();
-                let right: HashSet<SpaceCoordinates> =
-                    self.transition_expr(&self.right, coords).into_iter().collect();
+                let left: HashSet<SpaceCoordinates> = self
+                    .transition_expr(&self.left, coords)
+                    .into_iter()
+                    .collect();
+                let right: HashSet<SpaceCoordinates> = self
+                    .transition_expr(&self.right, coords)
+                    .into_iter()
+                    .collect();
                 let mut merged: Vec<SpaceCoordinates> =
                     left.intersection(&right).cloned().collect();
                 merged.sort_by(|a, b| a.raw.cmp(&b.raw));
@@ -212,24 +216,24 @@ impl ComposedField {
                 Some(axes) => {
                     let left_coords = SpaceCoordinates::new(coords.raw[..axes].to_vec());
                     let right_coords = SpaceCoordinates::new(coords.raw[axes..].to_vec());
-                    let left_targets: Vec<SpaceCoordinates> =
-                        self.transition_expr(&self.left, &left_coords)
-                            .into_iter()
-                            .map(|c| {
-                                let mut raw = c.raw;
-                                raw.extend(right_coords.raw.clone());
-                                SpaceCoordinates::new(raw)
-                            })
-                            .collect();
-                    let right_targets: Vec<SpaceCoordinates> =
-                        self.transition_expr(&self.right, &right_coords)
-                            .into_iter()
-                            .map(|c| {
-                                let mut raw = left_coords.raw.clone();
-                                raw.extend(c.raw);
-                                SpaceCoordinates::new(raw)
-                            })
-                            .collect();
+                    let left_targets: Vec<SpaceCoordinates> = self
+                        .transition_expr(&self.left, &left_coords)
+                        .into_iter()
+                        .map(|c| {
+                            let mut raw = c.raw;
+                            raw.extend(right_coords.raw.clone());
+                            SpaceCoordinates::new(raw)
+                        })
+                        .collect();
+                    let right_targets: Vec<SpaceCoordinates> = self
+                        .transition_expr(&self.right, &right_coords)
+                        .into_iter()
+                        .map(|c| {
+                            let mut raw = left_coords.raw.clone();
+                            raw.extend(c.raw);
+                            SpaceCoordinates::new(raw)
+                        })
+                        .collect();
                     let mut merged: Vec<SpaceCoordinates> = left_targets;
                     merged.extend(right_targets);
                     merged.sort_by(|a, b| a.raw.cmp(&b.raw));
@@ -237,10 +241,14 @@ impl ComposedField {
                     merged
                 }
                 None => {
-                    let left: HashSet<SpaceCoordinates> =
-                        self.transition_expr(&self.left, coords).into_iter().collect();
-                    let right: HashSet<SpaceCoordinates> =
-                        self.transition_expr(&self.right, coords).into_iter().collect();
+                    let left: HashSet<SpaceCoordinates> = self
+                        .transition_expr(&self.left, coords)
+                        .into_iter()
+                        .collect();
+                    let right: HashSet<SpaceCoordinates> = self
+                        .transition_expr(&self.right, coords)
+                        .into_iter()
+                        .collect();
                     let mut merged: Vec<SpaceCoordinates> =
                         left.intersection(&right).cloned().collect();
                     merged.sort_by(|a, b| a.raw.cmp(&b.raw));
@@ -259,7 +267,11 @@ impl ComposedField {
 
     // ---- internal helpers ----
 
-    fn transition_expr(&self, expr: &ComposedExpr, coords: &SpaceCoordinates) -> Vec<SpaceCoordinates> {
+    fn transition_expr(
+        &self,
+        expr: &ComposedExpr,
+        coords: &SpaceCoordinates,
+    ) -> Vec<SpaceCoordinates> {
         match expr {
             ComposedExpr::Field(f) => f.transition_targets(coords),
             ComposedExpr::Identity(_) => Vec::new(),

--- a/poc/standard/crates/field-synthesis/src/lib.rs
+++ b/poc/standard/crates/field-synthesis/src/lib.rs
@@ -159,6 +159,9 @@ impl ComposedField {
             CompositionOp::Product => {
                 match self.left_axes {
                     Some(axes) => {
+                        if axes > coords.raw.len() {
+                            return false;
+                        }
                         // Split coordinate space: left gets first `axes` axes, right gets the rest.
                         let left_coords = SpaceCoordinates::new(coords.raw[..axes].to_vec());
                         let right_coords = SpaceCoordinates::new(coords.raw[axes..].to_vec());
@@ -179,7 +182,6 @@ impl ComposedField {
         self.op
     }
 
-    /// Return a human-readable description of the composition expression.
     /// Return the merged transition targets from the composed Field.
     ///
     /// How transitions merge depends on the composition operation:
@@ -214,6 +216,9 @@ impl ComposedField {
             }
             CompositionOp::Product => match self.left_axes {
                 Some(axes) => {
+                    if axes > coords.raw.len() {
+                        return Vec::new();
+                    }
                     let left_coords = SpaceCoordinates::new(coords.raw[..axes].to_vec());
                     let right_coords = SpaceCoordinates::new(coords.raw[axes..].to_vec());
                     let left_targets: Vec<SpaceCoordinates> = self

--- a/poc/standard/crates/field-synthesis/src/lib.rs
+++ b/poc/standard/crates/field-synthesis/src/lib.rs
@@ -13,6 +13,7 @@
 //!
 //! These are not algebraic conveniences. They are the structure of inquiry made directly executable.
 
+use std::collections::HashSet;
 use std::fmt::Debug;
 
 pub use ssccs_core::{Constraint, Field, Projector, Segment, SpaceCoordinates};
@@ -179,6 +180,77 @@ impl ComposedField {
     }
 
     /// Return a human-readable description of the composition expression.
+    /// Return the merged transition targets from the composed Field.
+    ///
+    /// How transitions merge depends on the composition operation:
+    /// - Union: targets that exist in either sub-field
+    /// - Intersection: targets that exist in both sub-fields
+    /// - Product (no split): targets that exist in both sub-fields
+    /// - Product (with split): each sub-field transitions within its axis partition
+    pub fn transition_targets(&self, coords: &SpaceCoordinates) -> Vec<SpaceCoordinates> {
+        match self.op {
+            CompositionOp::Union => {
+                let left = self.transition_expr(&self.left, coords);
+                let right = self.transition_expr(&self.right, coords);
+                let mut merged: Vec<SpaceCoordinates> = left;
+                merged.extend(right);
+                merged.sort_by(|a, b| a.raw.cmp(&b.raw));
+                merged.dedup();
+                merged
+            }
+            CompositionOp::Intersection => {
+                let left: HashSet<SpaceCoordinates> =
+                    self.transition_expr(&self.left, coords).into_iter().collect();
+                let right: HashSet<SpaceCoordinates> =
+                    self.transition_expr(&self.right, coords).into_iter().collect();
+                let mut merged: Vec<SpaceCoordinates> =
+                    left.intersection(&right).cloned().collect();
+                merged.sort_by(|a, b| a.raw.cmp(&b.raw));
+                merged
+            }
+            CompositionOp::Product => match self.left_axes {
+                Some(axes) => {
+                    let left_coords = SpaceCoordinates::new(coords.raw[..axes].to_vec());
+                    let right_coords = SpaceCoordinates::new(coords.raw[axes..].to_vec());
+                    let left_targets: Vec<SpaceCoordinates> =
+                        self.transition_expr(&self.left, &left_coords)
+                            .into_iter()
+                            .map(|c| {
+                                let mut raw = c.raw;
+                                raw.extend(right_coords.raw.clone());
+                                SpaceCoordinates::new(raw)
+                            })
+                            .collect();
+                    let right_targets: Vec<SpaceCoordinates> =
+                        self.transition_expr(&self.right, &right_coords)
+                            .into_iter()
+                            .map(|c| {
+                                let mut raw = left_coords.raw.clone();
+                                raw.extend(c.raw);
+                                SpaceCoordinates::new(raw)
+                            })
+                            .collect();
+                    let mut merged: Vec<SpaceCoordinates> = left_targets;
+                    merged.extend(right_targets);
+                    merged.sort_by(|a, b| a.raw.cmp(&b.raw));
+                    merged.dedup();
+                    merged
+                }
+                None => {
+                    let left: HashSet<SpaceCoordinates> =
+                        self.transition_expr(&self.left, coords).into_iter().collect();
+                    let right: HashSet<SpaceCoordinates> =
+                        self.transition_expr(&self.right, coords).into_iter().collect();
+                    let mut merged: Vec<SpaceCoordinates> =
+                        left.intersection(&right).cloned().collect();
+                    merged.sort_by(|a, b| a.raw.cmp(&b.raw));
+                    merged
+                }
+            },
+        }
+    }
+
+    /// Return a human-readable description of the composition expression.
     pub fn describe(&self) -> String {
         let left_desc = self.describe_expr(&self.left);
         let right_desc = self.describe_expr(&self.right);
@@ -186,6 +258,14 @@ impl ComposedField {
     }
 
     // ---- internal helpers ----
+
+    fn transition_expr(&self, expr: &ComposedExpr, coords: &SpaceCoordinates) -> Vec<SpaceCoordinates> {
+        match expr {
+            ComposedExpr::Field(f) => f.transition_targets(coords),
+            ComposedExpr::Identity(_) => Vec::new(),
+            ComposedExpr::Composed(inner) => inner.transition_targets(coords),
+        }
+    }
 
     fn eval_left(&self, coords: &SpaceCoordinates) -> bool {
         self.eval_expr(&self.left, coords)

--- a/poc/standard/crates/field-synthesis/src/lib.rs
+++ b/poc/standard/crates/field-synthesis/src/lib.rs
@@ -1,17 +1,13 @@
 //! Field synthesis research crate.
 //!
-//! This crate explores techniques for synthesizing fields from high-level specifications
-//! and validates Field composition algebra: the epistemology of inquiry.
+//! This crate validates Field composition algebra: the epistemology of inquiry.
 //!
-//! ## Core Concept
+//! - **Union (∪)**: Broadens inquiry — admissible if any constituent Field allows it.
+//! - **Intersection (∩)**: Narrows focus — admissible only if all constituent Fields allow it.
+//! - **Product (×)**: Parallel independent investigation — each Field governs a disjoint
+//!   axis partition. Requires explicit `left_axes`.
 //!
-//! The philosophy document establishes that composing Fields is a form of epistemology:
-//!
-//! - **Union (∪)**: Broadens inquiry — a coordinate is admissible if any constituent Field allows it.
-//! - **Intersection (∩)**: Narrows focus — a coordinate is admissible only if all constituent Fields allow it.
-//! - **Product (×)**: Independent parallel investigation — constraints apply to disjoint axis partitions.
-//!
-//! These are not algebraic conveniences. They are the structure of inquiry made directly executable.
+//! These are not algebraic conveniences. They are the structure of inquiry made executable.
 
 use std::collections::HashSet;
 use std::fmt::Debug;
@@ -20,31 +16,22 @@ pub use ssccs_core::{Constraint, Field, Projector, Segment, SpaceCoordinates};
 
 // ==================== COMPOSITION OPERATION ====================
 
-/// The algebraic operation that composes two Fields.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CompositionOp {
-    /// Union (∪): coordinate is admissible if either Field allows it.
-    /// Broadens the inquiry.
     Union,
-    /// Intersection (∩): coordinate is admissible only if both Fields allow it.
-    /// Narrows the focus.
     Intersection,
-    /// Product (×): independent parallel investigation.
-    /// Left Field constrains the first k axes, right Field constrains the remaining axes.
     Product,
 }
 
 impl CompositionOp {
-    /// Returns the identity element for this operation.
     pub fn identity(&self) -> IdentityField {
         match self {
-            CompositionOp::Union => IdentityField::Empty, // A ∪ ∅ = A
-            CompositionOp::Intersection => IdentityField::Universal, // A ∩ ⊤ = A
-            CompositionOp::Product => IdentityField::Unit, // A × () = A
+            CompositionOp::Union => IdentityField::Empty,
+            CompositionOp::Intersection => IdentityField::Universal,
+            CompositionOp::Product => IdentityField::Unit,
         }
     }
 
-    /// Returns a human-readable symbol.
     pub fn symbol(&self) -> &'static str {
         match self {
             CompositionOp::Union => "∪",
@@ -54,59 +41,37 @@ impl CompositionOp {
     }
 }
 
-/// Special identity fields for algebraic operations.
 #[derive(Debug, Clone)]
 pub enum IdentityField {
-    /// Empty Field: no coordinate is admissible. Identity for Union.
     Empty,
-    /// Universal Field: every coordinate is admissible. Identity for Intersection.
     Universal,
-    /// Unit Field: zero-dimensional (single point). Identity for Product.
     Unit,
 }
 
 impl IdentityField {
-    /// Check whether a coordinate is admissible in this identity field.
-    pub fn allows(&self, _coords: &SpaceCoordinates) -> bool {
+    pub fn allows(&self, coords: &SpaceCoordinates) -> bool {
         match self {
             IdentityField::Empty => false,
             IdentityField::Universal => true,
-            IdentityField::Unit => {
-                // Zero-dimensional space: only the empty coordinate is admissible.
-                _coords.raw.is_empty()
-            }
+            IdentityField::Unit => coords.raw.is_empty(),
         }
     }
 }
 
 // ==================== COMPOSED FIELD ====================
 
-/// A Field composed from sub-Fields using an algebraic operation.
-///
-/// A ComposedField implements the epistemology of inquiry:
-/// - Union: "what if I ask broadly across multiple constraint regimes?"
-/// - Intersection: "what if I demand satisfaction across multiple criteria?"
-/// - Product: "what if I investigate independent dimensions simultaneously?"
 #[derive(Debug, Clone)]
 pub struct ComposedField {
-    /// The left (or first) sub-field.
     left: ComposedExpr,
-    /// The right (or second) sub-field.
     right: ComposedExpr,
-    /// The composition operation.
     op: CompositionOp,
-    /// Cached axis count for product operations.
     left_axes: Option<usize>,
 }
 
-/// A recursive expression tree for Field composition.
 #[derive(Debug, Clone)]
 pub enum ComposedExpr {
-    /// A concrete Field instance.
     Field(Field),
-    /// An identity field (empty, universal, or unit).
     Identity(IdentityField),
-    /// A nested composition.
     Composed(Box<ComposedField>),
 }
 
@@ -115,13 +80,11 @@ impl From<Field> for ComposedExpr {
         ComposedExpr::Field(f)
     }
 }
-
 impl From<IdentityField> for ComposedExpr {
     fn from(id: IdentityField) -> Self {
         ComposedExpr::Identity(id)
     }
 }
-
 impl From<ComposedField> for ComposedExpr {
     fn from(cf: ComposedField) -> Self {
         ComposedExpr::Composed(Box::new(cf))
@@ -129,7 +92,6 @@ impl From<ComposedField> for ComposedExpr {
 }
 
 impl ComposedField {
-    /// Create a new composed field from two sub-expressions and an operation.
     pub fn new(
         left: impl Into<ComposedExpr>,
         right: impl Into<ComposedExpr>,
@@ -143,95 +105,81 @@ impl ComposedField {
         }
     }
 
-    /// Set the axis count for the left operand in a Product composition.
-    /// This determines how many axes the left Field constrains.
     pub fn with_left_axes(mut self, axes: usize) -> Self {
         self.left_axes = Some(axes);
         self
     }
-
-    /// Evaluate whether a coordinate is admissible in the composed Field.
-    /// Delegates to the appropriate composition rule.
-    pub fn allows(&self, coords: &SpaceCoordinates) -> bool {
-        match self.op {
-            CompositionOp::Union => self.eval_left(coords) || self.eval_right(coords),
-            CompositionOp::Intersection => self.eval_left(coords) && self.eval_right(coords),
-            CompositionOp::Product => {
-                match self.left_axes {
-                    Some(axes) => {
-                        if axes > coords.raw.len() {
-                            return false;
-                        }
-                        // Split coordinate space: left gets first `axes` axes, right gets the rest.
-                        let left_coords = SpaceCoordinates::new(coords.raw[..axes].to_vec());
-                        let right_coords = SpaceCoordinates::new(coords.raw[axes..].to_vec());
-                        self.eval_expr(&self.left, &left_coords)
-                            && self.eval_expr(&self.right, &right_coords)
-                    }
-                    None => {
-                        // No split: both Fields see the full coordinate space independently.
-                        self.eval_left(coords) && self.eval_right(coords)
-                    }
-                }
-            }
-        }
-    }
-
-    /// Get the composition operation.
     pub fn op(&self) -> CompositionOp {
         self.op
     }
 
-    /// Return the merged transition targets from the composed Field.
-    ///
-    /// How transitions merge depends on the composition operation:
-    /// - Union: targets that exist in either sub-field
-    /// - Intersection: targets that exist in both sub-fields
-    /// - Product (no split): targets that exist in both sub-fields
-    /// - Product (with split): each sub-field transitions within its axis partition
+    // ---- admissibility ----
+
+    pub fn allows(&self, coords: &SpaceCoordinates) -> bool {
+        match self.op {
+            CompositionOp::Union => eval_expr(&self.left, coords) || eval_expr(&self.right, coords),
+            CompositionOp::Intersection => {
+                eval_expr(&self.left, coords) && eval_expr(&self.right, coords)
+            }
+            CompositionOp::Product => {
+                let axes = self
+                    .left_axes
+                    .expect("Product requires axis partition — use product() or with_left_axes()");
+                if axes > coords.raw.len() {
+                    return false;
+                }
+                let left_coords = SpaceCoordinates::new(coords.raw[..axes].to_vec());
+                let right_pass = if axes >= coords.raw.len() {
+                    true // all axes consumed; right field has zero dimensions
+                } else {
+                    let right_coords = SpaceCoordinates::new(coords.raw[axes..].to_vec());
+                    eval_expr(&self.right, &right_coords)
+                };
+                eval_expr(&self.left, &left_coords) && right_pass
+            }
+        }
+    }
+
+    // ---- transitions ----
+
     pub fn transition_targets(&self, coords: &SpaceCoordinates) -> Vec<SpaceCoordinates> {
         match self.op {
             CompositionOp::Union => {
-                let left = self.transition_expr(&self.left, coords);
-                let right = self.transition_expr(&self.right, coords);
-                let mut merged: Vec<SpaceCoordinates> = left;
-                merged.extend(right);
+                let mut merged = transition_expr(&self.left, coords);
+                merged.extend(transition_expr(&self.right, coords));
                 merged.sort_by(|a, b| a.raw.cmp(&b.raw));
                 merged.dedup();
                 merged
             }
             CompositionOp::Intersection => {
-                let left: HashSet<SpaceCoordinates> = self
-                    .transition_expr(&self.left, coords)
-                    .into_iter()
-                    .collect();
-                let right: HashSet<SpaceCoordinates> = self
-                    .transition_expr(&self.right, coords)
-                    .into_iter()
-                    .collect();
+                let left: HashSet<SpaceCoordinates> =
+                    transition_expr(&self.left, coords).into_iter().collect();
+                let right: HashSet<SpaceCoordinates> =
+                    transition_expr(&self.right, coords).into_iter().collect();
                 let mut merged: Vec<SpaceCoordinates> =
                     left.intersection(&right).cloned().collect();
                 merged.sort_by(|a, b| a.raw.cmp(&b.raw));
                 merged
             }
-            CompositionOp::Product => match self.left_axes {
-                Some(axes) => {
-                    if axes > coords.raw.len() {
-                        return Vec::new();
-                    }
-                    let left_coords = SpaceCoordinates::new(coords.raw[..axes].to_vec());
-                    let right_coords = SpaceCoordinates::new(coords.raw[axes..].to_vec());
-                    let left_targets: Vec<SpaceCoordinates> = self
-                        .transition_expr(&self.left, &left_coords)
-                        .into_iter()
-                        .map(|c| {
-                            let mut raw = c.raw;
-                            raw.extend(right_coords.raw.clone());
-                            SpaceCoordinates::new(raw)
-                        })
-                        .collect();
-                    let right_targets: Vec<SpaceCoordinates> = self
-                        .transition_expr(&self.right, &right_coords)
+            CompositionOp::Product => {
+                let axes = self
+                    .left_axes
+                    .expect("Product requires axis partition — use product() or with_left_axes()");
+                if axes > coords.raw.len() {
+                    return Vec::new();
+                }
+                let left_coords = SpaceCoordinates::new(coords.raw[..axes].to_vec());
+                let right_coords = SpaceCoordinates::new(coords.raw[axes..].to_vec());
+                let left_targets: Vec<SpaceCoordinates> = transition_expr(&self.left, &left_coords)
+                    .into_iter()
+                    .map(|c| {
+                        let mut raw = c.raw;
+                        raw.extend(right_coords.raw.clone());
+                        SpaceCoordinates::new(raw)
+                    })
+                    .collect();
+                let right_targets: Vec<SpaceCoordinates> =
+                    transition_expr(&self.right, &right_coords)
                         .into_iter()
                         .map(|c| {
                             let mut raw = left_coords.raw.clone();
@@ -239,94 +187,61 @@ impl ComposedField {
                             SpaceCoordinates::new(raw)
                         })
                         .collect();
-                    let mut merged: Vec<SpaceCoordinates> = left_targets;
-                    merged.extend(right_targets);
-                    merged.sort_by(|a, b| a.raw.cmp(&b.raw));
-                    merged.dedup();
-                    merged
-                }
-                None => {
-                    let left: HashSet<SpaceCoordinates> = self
-                        .transition_expr(&self.left, coords)
-                        .into_iter()
-                        .collect();
-                    let right: HashSet<SpaceCoordinates> = self
-                        .transition_expr(&self.right, coords)
-                        .into_iter()
-                        .collect();
-                    let mut merged: Vec<SpaceCoordinates> =
-                        left.intersection(&right).cloned().collect();
-                    merged.sort_by(|a, b| a.raw.cmp(&b.raw));
-                    merged
-                }
-            },
+                let mut merged = left_targets;
+                merged.extend(right_targets);
+                merged.sort_by(|a, b| a.raw.cmp(&b.raw));
+                merged.dedup();
+                merged
+            }
         }
     }
 
-    /// Return a human-readable description of the composition expression.
     pub fn describe(&self) -> String {
-        let left_desc = self.describe_expr(&self.left);
-        let right_desc = self.describe_expr(&self.right);
-        format!("({} {} {})", left_desc, self.op.symbol(), right_desc)
+        format!(
+            "({} {} {})",
+            describe_expr(&self.left),
+            self.op.symbol(),
+            describe_expr(&self.right)
+        )
     }
+}
 
-    // ---- internal helpers ----
+// ---- free evaluation functions ----
 
-    fn transition_expr(
-        &self,
-        expr: &ComposedExpr,
-        coords: &SpaceCoordinates,
-    ) -> Vec<SpaceCoordinates> {
-        match expr {
-            ComposedExpr::Field(f) => f.transition_targets(coords),
-            ComposedExpr::Identity(_) => Vec::new(),
-            ComposedExpr::Composed(inner) => inner.transition_targets(coords),
-        }
+fn eval_expr(expr: &ComposedExpr, coords: &SpaceCoordinates) -> bool {
+    match expr {
+        ComposedExpr::Field(f) => f.allows(coords),
+        ComposedExpr::Identity(id) => id.allows(coords),
+        ComposedExpr::Composed(inner) => inner.allows(coords),
     }
+}
 
-    fn eval_left(&self, coords: &SpaceCoordinates) -> bool {
-        self.eval_expr(&self.left, coords)
+fn transition_expr(expr: &ComposedExpr, coords: &SpaceCoordinates) -> Vec<SpaceCoordinates> {
+    match expr {
+        ComposedExpr::Field(f) => f.transition_targets(coords),
+        ComposedExpr::Identity(_) => Vec::new(),
+        ComposedExpr::Composed(inner) => inner.transition_targets(coords),
     }
+}
 
-    fn eval_right(&self, coords: &SpaceCoordinates) -> bool {
-        self.eval_expr(&self.right, coords)
-    }
-
-    fn eval_expr(&self, expr: &ComposedExpr, coords: &SpaceCoordinates) -> bool {
-        match expr {
-            ComposedExpr::Field(f) => f.allows(coords),
-            ComposedExpr::Identity(id) => id.allows(coords),
-            ComposedExpr::Composed(inner) => inner.allows(coords),
-        }
-    }
-
-    fn describe_expr(&self, expr: &ComposedExpr) -> String {
-        match expr {
-            ComposedExpr::Field(f) => format!("Field({})", f.describe_constraints()),
-            ComposedExpr::Identity(id) => match id {
-                IdentityField::Empty => "∅".to_string(),
-                IdentityField::Universal => "⊤".to_string(),
-                IdentityField::Unit => "()".to_string(),
-            },
-            ComposedExpr::Composed(inner) => inner.describe(),
-        }
+fn describe_expr(expr: &ComposedExpr) -> String {
+    match expr {
+        ComposedExpr::Field(f) => format!("Field({})", f.describe_constraints()),
+        ComposedExpr::Identity(id) => match id {
+            IdentityField::Empty => "∅".to_string(),
+            IdentityField::Universal => "⊤".to_string(),
+            IdentityField::Unit => "()".to_string(),
+        },
+        ComposedExpr::Composed(inner) => inner.describe(),
     }
 }
 
 // ==================== FIELD SYNTHESIS FUNCTIONS ====================
 
-/// Construct a Field that represents the **union** of two constraint regimes.
-/// A coordinate is admissible if either constituent Field allows it.
-///
-/// Corresponds to broadening the inquiry.
 pub fn union(left: impl Into<ComposedExpr>, right: impl Into<ComposedExpr>) -> ComposedField {
     ComposedField::new(left, right, CompositionOp::Union)
 }
 
-/// Construct a Field that represents the **intersection** of two constraint regimes.
-/// A coordinate is admissible only if both constituent Fields allow it.
-///
-/// Corresponds to narrowing the focus.
 pub fn intersection(
     left: impl Into<ComposedExpr>,
     right: impl Into<ComposedExpr>,
@@ -334,15 +249,29 @@ pub fn intersection(
     ComposedField::new(left, right, CompositionOp::Intersection)
 }
 
-/// Construct a Field that represents the **product** of two constraint regimes.
-/// Each Field constrains an independent axis partition.
-/// `left_axes` specifies how many axes the left Field governs.
-///
-/// Corresponds to pursuing independent lines of investigation in parallel.
 pub fn product(
     left: impl Into<ComposedExpr>,
     right: impl Into<ComposedExpr>,
     left_axes: usize,
 ) -> ComposedField {
     ComposedField::new(left, right, CompositionOp::Product).with_left_axes(left_axes)
+}
+
+// ==================== OBSERVATION BRIDGE ====================
+
+/// Observe a Segment through a composed Field.
+///
+/// The composed Field gates projection: only coordinates that satisfy all composition
+/// rules produce a result. This bridges composition (the epistemology of inquiry) with
+/// the observation pipeline — making "directly executable" structurally real.
+pub fn compose_observe<P: Projector>(
+    composed: &ComposedField,
+    projector: &P,
+    segment: &Segment,
+) -> Option<P::Output> {
+    if composed.allows(segment.coordinates()) {
+        projector.project(&Field::new(), segment)
+    } else {
+        None
+    }
 }

--- a/poc/standard/crates/field-synthesis/src/lib.rs
+++ b/poc/standard/crates/field-synthesis/src/lib.rs
@@ -1,9 +1,251 @@
 //! Field synthesis research crate.
-//! This crate explores techniques for synthesizing fields from high-level specifications.
+//!
+//! This crate explores techniques for synthesizing fields from high-level specifications
+//! and validates Field composition algebra: the epistemology of inquiry.
+//!
+//! ## Core Concept
+//!
+//! The philosophy document establishes that composing Fields is a form of epistemology:
+//!
+//! - **Union (∪)**: Broadens inquiry — a coordinate is admissible if any constituent Field allows it.
+//! - **Intersection (∩)**: Narrows focus — a coordinate is admissible only if all constituent Fields allow it.
+//! - **Product (×)**: Independent parallel investigation — constraints apply to disjoint axis partitions.
+//!
+//! These are not algebraic conveniences. They are the structure of inquiry made directly executable.
 
-pub use ssccs_core::{Constraint, Field, Segment, SpaceCoordinates};
+use std::fmt::Debug;
 
-// Placeholder for future research.
-pub fn synthesize_field() -> Field {
-    Field::new()
+pub use ssccs_core::{Constraint, Field, Projector, Segment, SpaceCoordinates};
+
+// ==================== COMPOSITION OPERATION ====================
+
+/// The algebraic operation that composes two Fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CompositionOp {
+    /// Union (∪): coordinate is admissible if either Field allows it.
+    /// Broadens the inquiry.
+    Union,
+    /// Intersection (∩): coordinate is admissible only if both Fields allow it.
+    /// Narrows the focus.
+    Intersection,
+    /// Product (×): independent parallel investigation.
+    /// Left Field constrains the first k axes, right Field constrains the remaining axes.
+    Product,
+}
+
+impl CompositionOp {
+    /// Returns the identity element for this operation.
+    pub fn identity(&self) -> IdentityField {
+        match self {
+            CompositionOp::Union => IdentityField::Empty, // A ∪ ∅ = A
+            CompositionOp::Intersection => IdentityField::Universal, // A ∩ ⊤ = A
+            CompositionOp::Product => IdentityField::Unit, // A × () = A
+        }
+    }
+
+    /// Returns a human-readable symbol.
+    pub fn symbol(&self) -> &'static str {
+        match self {
+            CompositionOp::Union => "∪",
+            CompositionOp::Intersection => "∩",
+            CompositionOp::Product => "×",
+        }
+    }
+}
+
+/// Special identity fields for algebraic operations.
+#[derive(Debug, Clone)]
+pub enum IdentityField {
+    /// Empty Field: no coordinate is admissible. Identity for Union.
+    Empty,
+    /// Universal Field: every coordinate is admissible. Identity for Intersection.
+    Universal,
+    /// Unit Field: zero-dimensional (single point). Identity for Product.
+    Unit,
+}
+
+impl IdentityField {
+    /// Check whether a coordinate is admissible in this identity field.
+    pub fn allows(&self, _coords: &SpaceCoordinates) -> bool {
+        match self {
+            IdentityField::Empty => false,
+            IdentityField::Universal => true,
+            IdentityField::Unit => {
+                // Zero-dimensional space: only the empty coordinate is admissible.
+                _coords.raw.is_empty()
+            }
+        }
+    }
+}
+
+// ==================== COMPOSED FIELD ====================
+
+/// A Field composed from sub-Fields using an algebraic operation.
+///
+/// A ComposedField implements the epistemology of inquiry:
+/// - Union: "what if I ask broadly across multiple constraint regimes?"
+/// - Intersection: "what if I demand satisfaction across multiple criteria?"
+/// - Product: "what if I investigate independent dimensions simultaneously?"
+#[derive(Debug, Clone)]
+pub struct ComposedField {
+    /// The left (or first) sub-field.
+    left: ComposedExpr,
+    /// The right (or second) sub-field.
+    right: ComposedExpr,
+    /// The composition operation.
+    op: CompositionOp,
+    /// Cached axis count for product operations.
+    left_axes: Option<usize>,
+}
+
+/// A recursive expression tree for Field composition.
+#[derive(Debug, Clone)]
+pub enum ComposedExpr {
+    /// A concrete Field instance.
+    Field(Field),
+    /// An identity field (empty, universal, or unit).
+    Identity(IdentityField),
+    /// A nested composition.
+    Composed(Box<ComposedField>),
+}
+
+impl From<Field> for ComposedExpr {
+    fn from(f: Field) -> Self {
+        ComposedExpr::Field(f)
+    }
+}
+
+impl From<IdentityField> for ComposedExpr {
+    fn from(id: IdentityField) -> Self {
+        ComposedExpr::Identity(id)
+    }
+}
+
+impl From<ComposedField> for ComposedExpr {
+    fn from(cf: ComposedField) -> Self {
+        ComposedExpr::Composed(Box::new(cf))
+    }
+}
+
+impl ComposedField {
+    /// Create a new composed field from two sub-expressions and an operation.
+    pub fn new(
+        left: impl Into<ComposedExpr>,
+        right: impl Into<ComposedExpr>,
+        op: CompositionOp,
+    ) -> Self {
+        Self {
+            left: left.into(),
+            right: right.into(),
+            op,
+            left_axes: None,
+        }
+    }
+
+    /// Set the axis count for the left operand in a Product composition.
+    /// This determines how many axes the left Field constrains.
+    pub fn with_left_axes(mut self, axes: usize) -> Self {
+        self.left_axes = Some(axes);
+        self
+    }
+
+    /// Evaluate whether a coordinate is admissible in the composed Field.
+    /// Delegates to the appropriate composition rule.
+    pub fn allows(&self, coords: &SpaceCoordinates) -> bool {
+        match self.op {
+            CompositionOp::Union => self.eval_left(coords) || self.eval_right(coords),
+            CompositionOp::Intersection => self.eval_left(coords) && self.eval_right(coords),
+            CompositionOp::Product => {
+                match self.left_axes {
+                    Some(axes) => {
+                        // Split coordinate space: left gets first `axes` axes, right gets the rest.
+                        let left_coords = SpaceCoordinates::new(coords.raw[..axes].to_vec());
+                        let right_coords = SpaceCoordinates::new(coords.raw[axes..].to_vec());
+                        self.eval_expr(&self.left, &left_coords)
+                            && self.eval_expr(&self.right, &right_coords)
+                    }
+                    None => {
+                        // No split: both Fields see the full coordinate space independently.
+                        self.eval_left(coords) && self.eval_right(coords)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get the composition operation.
+    pub fn op(&self) -> CompositionOp {
+        self.op
+    }
+
+    /// Return a human-readable description of the composition expression.
+    pub fn describe(&self) -> String {
+        let left_desc = self.describe_expr(&self.left);
+        let right_desc = self.describe_expr(&self.right);
+        format!("({} {} {})", left_desc, self.op.symbol(), right_desc)
+    }
+
+    // ---- internal helpers ----
+
+    fn eval_left(&self, coords: &SpaceCoordinates) -> bool {
+        self.eval_expr(&self.left, coords)
+    }
+
+    fn eval_right(&self, coords: &SpaceCoordinates) -> bool {
+        self.eval_expr(&self.right, coords)
+    }
+
+    fn eval_expr(&self, expr: &ComposedExpr, coords: &SpaceCoordinates) -> bool {
+        match expr {
+            ComposedExpr::Field(f) => f.allows(coords),
+            ComposedExpr::Identity(id) => id.allows(coords),
+            ComposedExpr::Composed(inner) => inner.allows(coords),
+        }
+    }
+
+    fn describe_expr(&self, expr: &ComposedExpr) -> String {
+        match expr {
+            ComposedExpr::Field(f) => format!("Field({})", f.describe_constraints()),
+            ComposedExpr::Identity(id) => match id {
+                IdentityField::Empty => "∅".to_string(),
+                IdentityField::Universal => "⊤".to_string(),
+                IdentityField::Unit => "()".to_string(),
+            },
+            ComposedExpr::Composed(inner) => inner.describe(),
+        }
+    }
+}
+
+// ==================== FIELD SYNTHESIS FUNCTIONS ====================
+
+/// Construct a Field that represents the **union** of two constraint regimes.
+/// A coordinate is admissible if either constituent Field allows it.
+///
+/// Corresponds to broadening the inquiry.
+pub fn union(left: impl Into<ComposedExpr>, right: impl Into<ComposedExpr>) -> ComposedField {
+    ComposedField::new(left, right, CompositionOp::Union)
+}
+
+/// Construct a Field that represents the **intersection** of two constraint regimes.
+/// A coordinate is admissible only if both constituent Fields allow it.
+///
+/// Corresponds to narrowing the focus.
+pub fn intersection(
+    left: impl Into<ComposedExpr>,
+    right: impl Into<ComposedExpr>,
+) -> ComposedField {
+    ComposedField::new(left, right, CompositionOp::Intersection)
+}
+
+/// Construct a Field that represents the **product** of two constraint regimes.
+/// Each Field constrains an independent axis partition.
+/// `left_axes` specifies how many axes the left Field governs.
+///
+/// Corresponds to pursuing independent lines of investigation in parallel.
+pub fn product(
+    left: impl Into<ComposedExpr>,
+    right: impl Into<ComposedExpr>,
+    left_axes: usize,
+) -> ComposedField {
+    ComposedField::new(left, right, CompositionOp::Product).with_left_axes(left_axes)
 }

--- a/poc/standard/crates/field-synthesis/src/main.rs
+++ b/poc/standard/crates/field-synthesis/src/main.rs
@@ -40,6 +40,7 @@ fn main() {
             test_admissibility_composition,
         ),
         ("9. Expression Description", test_expression_description),
+        ("10. Transition Composition", test_transition_composition),
     ];
 
     let mut passed = 0u32;
@@ -476,4 +477,70 @@ fn test_expression_description() {
     let id_desc = with_id.describe();
     assert!(id_desc.contains('\u{2205}'), "Should contain empty symbol");
     println!("  Identity:   {}", id_desc);
+}
+
+// ==================== TEST 10: TRANSITION COMPOSITION ====================
+
+fn test_transition_composition() {
+    // Build fields with transitions for composition testing
+    let mut field_x = Field::new();
+    field_x.add_transition(coord(0, 0, 0), coord(1, 0, 0), 1.0);
+    field_x.add_transition(coord(0, 0, 0), coord(2, 0, 0), 0.5);
+
+    let mut field_y = Field::new();
+    field_y.add_transition(coord(0, 0, 0), coord(2, 0, 0), 0.8);
+    field_y.add_transition(coord(0, 0, 0), coord(3, 0, 0), 1.0);
+
+    let origin = coord(0, 0, 0);
+
+    // Union: (X ∪ Y) at (0,0,0) → targets from both: [(1,0,0), (2,0,0), (3,0,0)]
+    let union_xy = union(field_x.clone(), field_y.clone());
+    let union_targets = union_xy.transition_targets(&origin);
+    assert!(
+        union_targets.contains(&coord(1, 0, 0)),
+        "Union should include (1,0,0) from X"
+    );
+    assert!(
+        union_targets.contains(&coord(2, 0, 0)),
+        "Union should include (2,0,0) from both"
+    );
+    assert!(
+        union_targets.contains(&coord(3, 0, 0)),
+        "Union should include (3,0,0) from Y"
+    );
+    assert_eq!(union_targets.len(), 3, "Union should have 3 unique targets");
+
+    // Intersection: (X ∩ Y) at (0,0,0) → targets common to both: [(2,0,0)]
+    let inter_xy = intersection(field_x.clone(), field_y.clone());
+    let inter_targets = inter_xy.transition_targets(&origin);
+    assert!(
+        inter_targets.contains(&coord(2, 0, 0)),
+        "Intersection should include (2,0,0) common to both"
+    );
+    assert_eq!(inter_targets.len(), 1, "Intersection should have 1 target");
+
+    // Product (no split): (X × Y) at (0,0,0) → targets common to both: [(2,0,0)]
+    let prod_xy = ComposedField::new(field_x.clone(), field_y.clone(), CompositionOp::Product);
+    let prod_targets = prod_xy.transition_targets(&origin);
+    assert!(
+        prod_targets.contains(&coord(2, 0, 0)),
+        "Product (no split) should include (2,0,0) common to both"
+    );
+    assert_eq!(prod_targets.len(), 1, "Product (no split) should have 1 target");
+
+    // Identity: ∅ has no transitions
+    let union_with_empty = union(field_x.clone(), IdentityField::Empty);
+    let empty_targets = union_with_empty.transition_targets(&origin);
+    assert_eq!(
+        empty_targets.len(),
+        2,
+        "Union with empty should retain all targets from X"
+    );
+    assert!(empty_targets.contains(&coord(1, 0, 0)));
+    assert!(empty_targets.contains(&coord(2, 0, 0)));
+
+    println!("  X ∪ Y targets: {:?}", union_targets.iter().map(|c| &c.raw).collect::<Vec<_>>());
+    println!("  X ∩ Y targets: {:?}", inter_targets.iter().map(|c| &c.raw).collect::<Vec<_>>());
+    println!("  X × Y targets: {:?}", prod_targets.iter().map(|c| &c.raw).collect::<Vec<_>>());
+    println!("  → Transition topology is preserved through Field composition.");
 }

--- a/poc/standard/crates/field-synthesis/src/main.rs
+++ b/poc/standard/crates/field-synthesis/src/main.rs
@@ -3,24 +3,30 @@
 //! Validates that Fields can be composed through union, intersection, and product
 //! operations, and that these compositions satisfy expected algebraic properties.
 //!
-//! ## Background
+//! ## Structure
 //!
-//! The SSCCS philosophy establishes that "the manner in which we combine questions
-//! becomes a form of epistemology":
+//! - Algebraic laws (tests 1–11): commutativity, associativity, distributivity, etc.
+//! - `test_compose_observe`: the bridge from composed Fields to the observation pipeline.
+//! - `Scenario` module: domain-specific scenarios demonstrating composition with
+//!   heterogeneous axes — time, space, temperature, sensor identity, etc.
 //!
-//! - **Union (∪)**: Broadens inquiry — admissible if either Field allows.
-//! - **Intersection (∩)**: Narrows focus — admissible only if both allow.
-//! - **Product (×)**: Parallel independent investigation — each Field governs
-//!   a disjoint axis partition.
+//! Adding a scenario requires only implementing the `Scenario` trait and registering it.
 
 use ssccs_core::{Field, Segment, SpaceCoordinates};
 use ssccs_examples::{CoordinateSumProjector, EvenConstraint, RangeConstraint};
 use ssccs_field_synthesis::{IdentityField, compose_observe, intersection, product, union};
 
+mod scenarios;
+use scenarios::Scenario;
+
 fn main() {
     println!("=== Field Synthesis: Composition Algebra ===\n");
 
-    let tests: Vec<(&str, fn())> = vec![
+    let mut passed = 0u32;
+    let mut failed = 0u32;
+
+    // ── algebraic laws ──
+    let laws: Vec<(&str, fn())> = vec![
         ("1. Identity Elements", test_identity),
         ("2. Commutativity", test_commutativity),
         ("3. Associativity", test_associativity),
@@ -33,42 +39,56 @@ fn main() {
         ("10. Transition Composition", test_transition),
         ("11. Idempotence", test_idempotence),
         ("12. compose_observe Bridge", test_compose_observe),
-        ("13. Inquiry Over Structure", test_inquiry_over_structure),
     ];
 
-    let mut passed = 0u32;
-    let mut failed = 0u32;
-
-    for (name, test_fn) in &tests {
+    for (name, test_fn) in &laws {
         print!("  {} ... ", name);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test_fn));
-        match result {
-            Ok(()) => {
-                println!("PASSED");
-                passed += 1;
+        if result.is_ok() {
+            println!("PASSED");
+            passed += 1;
+        } else {
+            println!("FAILED");
+            if let Err(e) = result {
+                if let Some(m) = e.downcast_ref::<&str>() {
+                    println!("    Reason: {}", m);
+                }
             }
-            Err(e) => {
-                println!("FAILED");
+            failed += 1;
+        }
+    }
+
+    // ── scenarios ──
+    for s in scenarios::registry() {
+        print!("  Scenario: {} ... ", s.name());
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| s.run()));
+        if result.is_ok() {
+            println!("PASSED");
+            passed += 1;
+        } else {
+            println!("FAILED");
+            if let Err(e) = result {
                 if let Some(m) = e.downcast_ref::<&str>() {
                     println!("    Reason: {}", m);
                 } else if let Some(m) = e.downcast_ref::<String>() {
                     println!("    Reason: {}", m);
                 }
-                failed += 1;
             }
+            failed += 1;
         }
     }
 
+    let total = laws.len() + scenarios::registry().len();
     println!(
         "\nResults: {} passed, {} failed out of {} tests",
-        passed,
-        failed,
-        tests.len()
+        passed, failed, total
     );
     if failed > 0 {
         std::process::exit(1);
     }
 }
+
+// ==================== HELPERS ====================
 
 fn coord(x: i64, y: i64, z: i64) -> SpaceCoordinates {
     SpaceCoordinates::new(vec![x, y, z])
@@ -96,7 +116,7 @@ fn field_c() -> Field {
     f
 }
 
-// ==================== TESTS ====================
+// ==================== LAWS 1–12 ====================
 
 fn test_identity() {
     let u = union(field_a(), IdentityField::Empty);
@@ -127,7 +147,6 @@ fn test_commutativity() {
     for c in &tests {
         assert_eq!(ab.allows(c), ba.allows(c));
     }
-
     let ab = intersection(field_a(), field_b());
     let ba = intersection(field_b(), field_a());
     for c in &tests {
@@ -152,7 +171,6 @@ fn test_associativity() {
     for t in &tests {
         assert_eq!(l.allows(t), r.allows(t));
     }
-
     let l = intersection(intersection(a.clone(), b.clone()), c.clone());
     let r = intersection(a.clone(), intersection(b.clone(), c.clone()));
     for t in &tests {
@@ -169,16 +187,14 @@ fn test_absorption() {
         coord(3, 1, 0),
         coord(3, 10, 0),
     ];
-
-    let la = union(a.clone(), intersection(a.clone(), b.clone()));
+    let l = union(a.clone(), intersection(a.clone(), b.clone()));
     for t in &tests {
-        assert_eq!(la.allows(t), a.allows(t));
+        assert_eq!(l.allows(t), a.allows(t));
     }
-
-    let la = intersection(a.clone(), union(a, b));
+    let l = intersection(a.clone(), union(a, b));
     let a2 = field_a();
     for t in &tests {
-        assert_eq!(la.allows(t), a2.allows(t));
+        assert_eq!(l.allows(t), a2.allows(t));
     }
 }
 
@@ -208,7 +224,6 @@ fn test_product() {
     let mut fa = Field::new();
     fa.add_constraint(RangeConstraint::new(0, 0, 10));
     fa.add_constraint(EvenConstraint::new(0));
-
     let pa = product(fa.clone(), IdentityField::Unit, 1);
     assert!(pa.allows(&coord_1d(2)));
     assert!(!pa.allows(&coord_1d(3)));
@@ -223,7 +238,6 @@ fn test_nested() {
     assert!(n.allows(&coord(2, 1, 2)));
     assert!(n.allows(&coord(2, 10, 2)));
     assert!(!n.allows(&coord(3, 1, 5)));
-
     let t = intersection(intersection(a.clone(), b.clone()), c.clone());
     assert!(t.allows(&coord(2, 1, 2)));
     assert!(!t.allows(&coord(3, 1, 2)));
@@ -237,12 +251,10 @@ fn test_admissibility() {
     let c = field_c();
     let narrow = intersection(intersection(a.clone(), b.clone()), c.clone());
     let broad = union(union(a.clone(), b.clone()), c.clone());
-
     assert!(narrow.allows(&coord(2, 1, 2)));
     assert!(!narrow.allows(&coord(3, 10, 5)));
     assert!(!narrow.allows(&coord(2, 10, 5)));
     assert!(broad.allows(&coord(2, 10, 5)));
-
     println!("  Same coord (2,10,5): Narrow=false, Broad=true");
 }
 
@@ -262,34 +274,28 @@ fn test_transition() {
     let mut x = Field::new();
     x.add_transition(coord(0, 0, 0), coord(1, 0, 0), 1.0);
     x.add_transition(coord(0, 0, 0), coord(2, 0, 0), 0.5);
-
     let mut y = Field::new();
     y.add_transition(coord(0, 0, 0), coord(2, 0, 0), 0.8);
     y.add_transition(coord(0, 0, 0), coord(3, 0, 0), 1.0);
-
     let o = coord(0, 0, 0);
-
-    let ut = union(x.clone(), y.clone()).transition_targets(&o);
-    assert_eq!(ut.len(), 3);
-
+    assert_eq!(union(x.clone(), y.clone()).transition_targets(&o).len(), 3);
     let it = intersection(x.clone(), y.clone()).transition_targets(&o);
     assert_eq!(it.len(), 1);
     assert!(it.contains(&coord(2, 0, 0)));
-
     println!(
-        "  X ∪ Y: {:?}",
-        ut.iter().map(|c| &c.raw).collect::<Vec<_>>()
+        "  X∪Y: {:?}",
+        union(x, y)
+            .transition_targets(&o)
+            .iter()
+            .map(|c| &c.raw)
+            .collect::<Vec<_>>()
     );
-    println!(
-        "  X ∩ Y: {:?}",
-        it.iter().map(|c| &c.raw).collect::<Vec<_>>()
-    );
+    println!("  X∩Y: {:?}", it.iter().map(|c| &c.raw).collect::<Vec<_>>());
 }
 
 fn test_idempotence() {
     let a = field_a();
-    let tests = [coord(2, 1, 0), coord(3, 1, 0), coord(12, 1, 0)];
-    for t in &tests {
+    for t in &[coord(2, 1, 0), coord(3, 1, 0), coord(12, 1, 0)] {
         assert_eq!(union(a.clone(), a.clone()).allows(t), a.allows(t));
         assert_eq!(intersection(a.clone(), a.clone()).allows(t), a.allows(t));
     }
@@ -302,75 +308,14 @@ fn test_idempotence() {
 fn test_compose_observe() {
     let narrow = intersection(intersection(field_a(), field_b()), field_c());
     let projector = CoordinateSumProjector;
-
     let seg = Segment::new(coord(2, 1, 2));
-    let obs = compose_observe(&narrow, &projector, &seg);
-    assert_eq!(obs, Some(5));
-
-    let seg_bad = Segment::new(coord(3, 10, 5));
-    assert!(compose_observe(&narrow, &projector, &seg_bad).is_none());
-
-    let seg_partial = Segment::new(coord(2, 10, 5));
-    assert!(compose_observe(&narrow, &projector, &seg_partial).is_none());
-
+    assert_eq!(compose_observe(&narrow, &projector, &seg), Some(5));
+    assert!(compose_observe(&narrow, &projector, &Segment::new(coord(3, 10, 5))).is_none());
+    assert!(compose_observe(&narrow, &projector, &Segment::new(coord(2, 10, 5))).is_none());
     println!(
-        "    A∩B∩C at (2,1,2): {:?}",
+        "  A∩B∩C at (2,1,2): {:?}",
         compose_observe(&narrow, &projector, &seg)
     );
-    println!(
-        "    A∩B∩C at (3,10,5): {:?}",
-        compose_observe(&narrow, &projector, &seg_bad)
-    );
-    println!(
-        "    A∩B∩C at (2,10,5): {:?}",
-        compose_observe(&narrow, &projector, &seg_partial)
-    );
+    println!("  A∩B∩C at (3,10,5): None");
     println!("  → Observation through composed Fields is structurally real.");
-}
-
-fn test_inquiry_over_structure() {
-    let mut fp = Field::new();
-    fp.add_constraint(EvenConstraint::new(0));
-    let mut fq = Field::new();
-    fq.add_constraint(RangeConstraint::new(1, 0, 1));
-
-    let segs: Vec<Segment> = (0..=2)
-        .flat_map(|y| (0..=2).map(move |x| Segment::new(SpaceCoordinates::new(vec![x, y]))))
-        .collect();
-    assert_eq!(segs.len(), 9);
-
-    let narrow = intersection(fp.clone(), fq.clone());
-    let narrow_count = segs
-        .iter()
-        .filter(|s| narrow.allows(s.coordinates()))
-        .count();
-    assert_eq!(narrow_count, 4);
-
-    let broad = union(fp.clone(), fq.clone());
-    let broad_count = segs
-        .iter()
-        .filter(|s| broad.allows(s.coordinates()))
-        .count();
-    assert_eq!(broad_count, 8);
-
-    let projector = CoordinateSumProjector;
-    let projections: Vec<i64> = segs
-        .iter()
-        .filter_map(|s| compose_observe(&narrow, &projector, s))
-        .collect();
-    assert_eq!(projections, vec![0, 2, 1, 3]);
-
-    let broad_projections: Vec<i64> = segs
-        .iter()
-        .filter_map(|s| compose_observe(&broad, &projector, s))
-        .collect();
-    assert_eq!(broad_projections.len(), 8);
-
-    println!("  P: axis[0] even, Q: axis[1] in [0,1] over 9-segment 2D space");
-    println!(
-        "  P∩Q (narrow): {} segments → sums: {:?}",
-        narrow_count, projections
-    );
-    println!("  P∪Q (broad):  {} segments", broad_count);
-    println!("  → Same structure, different inquiry, different observables.");
 }

--- a/poc/standard/crates/field-synthesis/src/main.rs
+++ b/poc/standard/crates/field-synthesis/src/main.rs
@@ -41,6 +41,7 @@ fn main() {
         ),
         ("9. Expression Description", test_expression_description),
         ("10. Transition Composition", test_transition_composition),
+        ("11. Idempotence", test_idempotence),
     ];
 
     let mut passed = 0u32;
@@ -556,4 +557,50 @@ fn test_transition_composition() {
         prod_targets.iter().map(|c| &c.raw).collect::<Vec<_>>()
     );
     println!("  → Transition topology is preserved through Field composition.");
+}
+
+// ==================== TEST 11: IDEMPOTENCE ====================
+
+fn test_idempotence() {
+    // A ∪ A = A
+    let fa = build_field_a();
+    let a_union_a = union(fa.clone(), fa.clone());
+    let test_coords = vec![coord(2, 1, 0), coord(3, 1, 0), coord(12, 1, 0)];
+    for c in &test_coords {
+        assert_eq!(
+            a_union_a.allows(c),
+            fa.allows(c),
+            "A ∪ A should equal A at {:?}",
+            c.raw
+        );
+    }
+
+    // A ∩ A = A
+    let a_inter_a = intersection(fa.clone(), fa.clone());
+    for c in &test_coords {
+        assert_eq!(
+            a_inter_a.allows(c),
+            fa.allows(c),
+            "A ∩ A should equal A at {:?}",
+            c.raw
+        );
+    }
+
+    // ∅ ∪ ∅ = ∅
+    let empty_empty = union(IdentityField::Empty, IdentityField::Empty);
+    assert!(
+        !empty_empty.allows(&coord(0, 0, 0)),
+        "∅ ∪ ∅ should be empty"
+    );
+
+    // ⊤ ∩ ⊤ = ⊤
+    let uni_uni = intersection(IdentityField::Universal, IdentityField::Universal);
+    assert!(
+        uni_uni.allows(&coord(999, 0, 0)),
+        "⊤ ∩ ⊤ should be universal"
+    );
+
+    println!("  A ∪ A = A, A ∩ A = A (verified across multiple coordinates)");
+    println!("  ∅ ∪ ∅ = ∅, ⊤ ∩ ⊤ = ⊤");
+    println!("  → All idempotence laws satisfied.");
 }

--- a/poc/standard/crates/field-synthesis/src/main.rs
+++ b/poc/standard/crates/field-synthesis/src/main.rs
@@ -526,7 +526,11 @@ fn test_transition_composition() {
         prod_targets.contains(&coord(2, 0, 0)),
         "Product (no split) should include (2,0,0) common to both"
     );
-    assert_eq!(prod_targets.len(), 1, "Product (no split) should have 1 target");
+    assert_eq!(
+        prod_targets.len(),
+        1,
+        "Product (no split) should have 1 target"
+    );
 
     // Identity: ∅ has no transitions
     let union_with_empty = union(field_x.clone(), IdentityField::Empty);
@@ -539,8 +543,17 @@ fn test_transition_composition() {
     assert!(empty_targets.contains(&coord(1, 0, 0)));
     assert!(empty_targets.contains(&coord(2, 0, 0)));
 
-    println!("  X ∪ Y targets: {:?}", union_targets.iter().map(|c| &c.raw).collect::<Vec<_>>());
-    println!("  X ∩ Y targets: {:?}", inter_targets.iter().map(|c| &c.raw).collect::<Vec<_>>());
-    println!("  X × Y targets: {:?}", prod_targets.iter().map(|c| &c.raw).collect::<Vec<_>>());
+    println!(
+        "  X ∪ Y targets: {:?}",
+        union_targets.iter().map(|c| &c.raw).collect::<Vec<_>>()
+    );
+    println!(
+        "  X ∩ Y targets: {:?}",
+        inter_targets.iter().map(|c| &c.raw).collect::<Vec<_>>()
+    );
+    println!(
+        "  X × Y targets: {:?}",
+        prod_targets.iter().map(|c| &c.raw).collect::<Vec<_>>()
+    );
     println!("  → Transition topology is preserved through Field composition.");
 }

--- a/poc/standard/crates/field-synthesis/src/main.rs
+++ b/poc/standard/crates/field-synthesis/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
         ("10. Transition Composition", test_transition),
         ("11. Idempotence", test_idempotence),
         ("12. compose_observe Bridge", test_compose_observe),
+        ("13. Inquiry Over Structure", test_inquiry_over_structure),
     ];
 
     let mut passed = 0u32;
@@ -325,4 +326,51 @@ fn test_compose_observe() {
         compose_observe(&narrow, &projector, &seg_partial)
     );
     println!("  → Observation through composed Fields is structurally real.");
+}
+
+fn test_inquiry_over_structure() {
+    let mut fp = Field::new();
+    fp.add_constraint(EvenConstraint::new(0));
+    let mut fq = Field::new();
+    fq.add_constraint(RangeConstraint::new(1, 0, 1));
+
+    let segs: Vec<Segment> = (0..=2)
+        .flat_map(|y| (0..=2).map(move |x| Segment::new(SpaceCoordinates::new(vec![x, y]))))
+        .collect();
+    assert_eq!(segs.len(), 9);
+
+    let narrow = intersection(fp.clone(), fq.clone());
+    let narrow_count = segs
+        .iter()
+        .filter(|s| narrow.allows(s.coordinates()))
+        .count();
+    assert_eq!(narrow_count, 4);
+
+    let broad = union(fp.clone(), fq.clone());
+    let broad_count = segs
+        .iter()
+        .filter(|s| broad.allows(s.coordinates()))
+        .count();
+    assert_eq!(broad_count, 8);
+
+    let projector = CoordinateSumProjector;
+    let projections: Vec<i64> = segs
+        .iter()
+        .filter_map(|s| compose_observe(&narrow, &projector, s))
+        .collect();
+    assert_eq!(projections, vec![0, 2, 1, 3]);
+
+    let broad_projections: Vec<i64> = segs
+        .iter()
+        .filter_map(|s| compose_observe(&broad, &projector, s))
+        .collect();
+    assert_eq!(broad_projections.len(), 8);
+
+    println!("  P: axis[0] even, Q: axis[1] in [0,1] over 9-segment 2D space");
+    println!(
+        "  P∩Q (narrow): {} segments → sums: {:?}",
+        narrow_count, projections
+    );
+    println!("  P∪Q (broad):  {} segments", broad_count);
+    println!("  → Same structure, different inquiry, different observables.");
 }

--- a/poc/standard/crates/field-synthesis/src/main.rs
+++ b/poc/standard/crates/field-synthesis/src/main.rs
@@ -1,0 +1,479 @@
+//! Field Synthesis Experiment: Field Composition Algebra
+//!
+//! Validates that Fields can be composed through union, intersection, and product
+//! operations, and that these compositions satisfy expected algebraic properties.
+//!
+//! ## Background
+//!
+//! The SSCCS philosophy establishes that "the manner in which we combine questions
+//! becomes a form of epistemology":
+//!
+//! - **Union (∪)**: Broaden the inquiry — combine Fields so that a coordinate is
+//!   admissible if either Field allows it.
+//! - **Intersection (∩)**: Narrow the focus — a coordinate is admissible only if
+//!   both Fields allow it.
+//! - **Product (×)**: Independent parallel investigation — each Field constrains
+//!   the same coordinate space independently, and all must agree.
+//!
+//! This experiment validates that these operations behave as a proper algebra:
+//! commutativity, associativity, identity elements, absorption, and distributivity,
+//! then demonstrates composition with actual constraints to show that the composed
+//! Field changes what is admissible.
+
+use ssccs_core::{Field, SpaceCoordinates};
+use ssccs_examples::{EvenConstraint, RangeConstraint};
+use ssccs_field_synthesis::{ComposedField, CompositionOp, IdentityField, intersection, union};
+
+fn main() {
+    println!("=== Field Synthesis: Composition Algebra ===\n");
+
+    let tests: Vec<(&str, fn())> = vec![
+        ("1. Identity Elements", test_identity_elements),
+        ("2. Commutativity", test_commutativity),
+        ("3. Associativity", test_associativity),
+        ("4. Absorption", test_absorption),
+        ("5. Distributivity", test_distributivity),
+        ("6. Product Semantics", test_product_semantics),
+        ("7. Nested Composition", test_nested_composition),
+        (
+            "8. Composition Changes Admissibility",
+            test_admissibility_composition,
+        ),
+        ("9. Expression Description", test_expression_description),
+    ];
+
+    let mut passed = 0u32;
+    let mut failed = 0u32;
+
+    for (name, test_fn) in &tests {
+        print!("  {} ... ", name);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test_fn));
+        match result {
+            Ok(()) => {
+                println!("PASSED");
+                passed += 1;
+            }
+            Err(e) => {
+                println!("FAILED");
+                if let Some(msg) = e.downcast_ref::<&str>() {
+                    println!("    Reason: {}", msg);
+                } else if let Some(msg) = e.downcast_ref::<String>() {
+                    println!("    Reason: {}", msg);
+                }
+                failed += 1;
+            }
+        }
+    }
+
+    println!(
+        "\nResults: {} passed, {} failed out of {} tests",
+        passed,
+        failed,
+        tests.len()
+    );
+    if failed > 0 {
+        std::process::exit(1);
+    }
+}
+
+// ==================== TEST FIELD CONSTRUCTORS ====================
+
+fn build_field_a() -> Field {
+    let mut f = Field::new();
+    f.add_constraint(RangeConstraint::new(0, 0, 10));
+    f.add_constraint(EvenConstraint::new(0));
+    f
+}
+
+fn build_field_b() -> Field {
+    let mut f = Field::new();
+    f.add_constraint(RangeConstraint::new(1, 0, 5));
+    f
+}
+
+fn build_field_c() -> Field {
+    let mut f = Field::new();
+    f.add_constraint(RangeConstraint::new(2, 0, 3));
+    f
+}
+
+// ==================== COORDINATE HELPERS ====================
+
+fn coord(x: i64, y: i64, z: i64) -> SpaceCoordinates {
+    SpaceCoordinates::new(vec![x, y, z])
+}
+
+// ==================== TEST 1: IDENTITY ELEMENTS ====================
+
+fn test_identity_elements() {
+    // Union identity: A ∪ ∅ = A
+    let union_with_empty = union(build_field_a(), IdentityField::Empty);
+    assert!(
+        union_with_empty.allows(&coord(2, 1, 0)),
+        "Union with empty should allow what A allows"
+    );
+    assert!(
+        !union_with_empty.allows(&coord(3, 1, 0)),
+        "Union with empty should reject what A rejects"
+    );
+    assert!(
+        !union_with_empty.allows(&coord(12, 1, 0)),
+        "Union with empty should reject out-of-range for A"
+    );
+
+    // Intersection identity: A ∩ ⊤ = A
+    let inter_with_universal = intersection(build_field_a(), IdentityField::Universal);
+    assert!(
+        inter_with_universal.allows(&coord(2, 1, 0)),
+        "Intersection with universal should allow what A allows"
+    );
+    assert!(
+        !inter_with_universal.allows(&coord(3, 1, 0)),
+        "Intersection with universal should reject what A rejects"
+    );
+
+    // Empty union empty = empty
+    let empty_empty = union(IdentityField::Empty, IdentityField::Empty);
+    assert!(
+        !empty_empty.allows(&coord(0, 0, 0)),
+        "Empty ∪ Empty should reject all coordinates"
+    );
+
+    // Universal intersected with universal = universal
+    let uni_uni = intersection(IdentityField::Universal, IdentityField::Universal);
+    assert!(
+        uni_uni.allows(&coord(999, -1, 100)),
+        "Universal ∩ Universal should allow everything"
+    );
+}
+
+// ==================== TEST 2: COMMUTATIVITY ====================
+
+fn test_commutativity() {
+    let a_union_b = union(build_field_a(), build_field_b());
+    let b_union_a = union(build_field_b(), build_field_a());
+
+    let test_coords = vec![
+        coord(2, 1, 0),
+        coord(2, 10, 0),
+        coord(3, 1, 0),
+        coord(3, 10, 0),
+        coord(4, 3, 5),
+    ];
+
+    for c in &test_coords {
+        assert_eq!(
+            a_union_b.allows(c),
+            b_union_a.allows(c),
+            "Union commutativity violated at {:?}",
+            c.raw
+        );
+    }
+
+    let a_inter_b = intersection(build_field_a(), build_field_b());
+    let b_inter_a = intersection(build_field_b(), build_field_a());
+
+    for c in &test_coords {
+        assert_eq!(
+            a_inter_b.allows(c),
+            b_inter_a.allows(c),
+            "Intersection commutativity violated at {:?}",
+            c.raw
+        );
+    }
+}
+
+// ==================== TEST 3: ASSOCIATIVITY ====================
+
+fn test_associativity() {
+    let fa = build_field_a();
+    let fb = build_field_b();
+    let fc = build_field_c();
+
+    // Union: (A ∪ B) ∪ C = A ∪ (B ∪ C)
+    let left_union = union(union(fa.clone(), fb.clone()), fc.clone());
+    let right_union = union(fa.clone(), union(fb.clone(), fc.clone()));
+
+    let test_coords = vec![
+        coord(2, 1, 1),
+        coord(3, 1, 1),
+        coord(2, 10, 1),
+        coord(2, 1, 5),
+        coord(3, 10, 5),
+        coord(4, 2, 2),
+    ];
+
+    for c in &test_coords {
+        assert_eq!(
+            left_union.allows(c),
+            right_union.allows(c),
+            "Union associativity violated at {:?}",
+            c.raw
+        );
+    }
+
+    // Intersection: (A ∩ B) ∩ C = A ∩ (B ∩ C)
+    let left_inter = intersection(intersection(fa.clone(), fb.clone()), fc.clone());
+    let right_inter = intersection(fa.clone(), intersection(fb.clone(), fc.clone()));
+
+    for c in &test_coords {
+        assert_eq!(
+            left_inter.allows(c),
+            right_inter.allows(c),
+            "Intersection associativity violated at {:?}",
+            c.raw
+        );
+    }
+}
+
+// ==================== TEST 4: ABSORPTION ====================
+
+fn test_absorption() {
+    let fa = build_field_a();
+    let fb = build_field_b();
+
+    let a_union_a_inter_b = union(fa.clone(), intersection(fa.clone(), fb.clone()));
+    let test_coords = vec![
+        coord(2, 1, 0),
+        coord(2, 10, 0),
+        coord(3, 1, 0),
+        coord(3, 10, 0),
+    ];
+
+    for c in &test_coords {
+        assert_eq!(
+            a_union_a_inter_b.allows(c),
+            fa.allows(c),
+            "Absorption law 1 violated at {:?}: A ∪ (A ∩ B) should equal A",
+            c.raw
+        );
+    }
+
+    let a_inter_a_union_b = intersection(fa.clone(), union(fa, fb));
+    let fa2 = build_field_a();
+
+    for c in &test_coords {
+        assert_eq!(
+            a_inter_a_union_b.allows(c),
+            fa2.allows(c),
+            "Absorption law 2 violated at {:?}: A ∩ (A ∪ B) should equal A",
+            c.raw
+        );
+    }
+}
+
+// ==================== TEST 5: DISTRIBUTIVITY ====================
+
+fn test_distributivity() {
+    let fa = build_field_a();
+    let fb = build_field_b();
+    let fc = build_field_c();
+
+    let a_inter_b_union_c = intersection(fa.clone(), union(fb.clone(), fc.clone()));
+    let a_inter_b_union_a_inter_c = union(
+        intersection(fa.clone(), fb.clone()),
+        intersection(fa.clone(), fc.clone()),
+    );
+
+    let test_coords = vec![
+        coord(2, 1, 1),
+        coord(3, 1, 1),
+        coord(2, 10, 1),
+        coord(2, 1, 5),
+        coord(2, 10, 5),
+        coord(4, 2, 2),
+    ];
+
+    for c in &test_coords {
+        assert_eq!(
+            a_inter_b_union_c.allows(c),
+            a_inter_b_union_a_inter_c.allows(c),
+            "Distributivity violated at {:?}: A ∩ (B ∪ C) = (A ∩ B) ∪ (A ∩ C)",
+            c.raw
+        );
+    }
+}
+
+// ==================== TEST 6: PRODUCT SEMANTICS ====================
+
+fn test_product_semantics() {
+    // Product: both Fields check the same coordinate space independently.
+    let prod = ComposedField::new(build_field_a(), build_field_b(), CompositionOp::Product);
+
+    // Field A: axis[0] even and in [0,10]; Field B: axis[1] in [0,5]
+    let coord_valid = coord(2, 3, 0);
+    let coord_a_rejects = coord(3, 3, 0);
+    let coord_b_rejects = coord(2, 10, 0);
+
+    assert!(
+        prod.allows(&coord_valid),
+        "Product should allow valid coordinate"
+    );
+    assert!(
+        !prod.allows(&coord_a_rejects),
+        "Product should reject when A rejects"
+    );
+    assert!(
+        !prod.allows(&coord_b_rejects),
+        "Product should reject when B rejects"
+    );
+
+    // Product is commutative: A × B = B × A
+    let prod_ba = ComposedField::new(build_field_b(), build_field_a(), CompositionOp::Product);
+    for c in &[
+        coord(2, 3, 0),
+        coord(3, 3, 0),
+        coord(2, 10, 0),
+        coord(11, 6, 0),
+    ] {
+        assert_eq!(
+            prod.allows(c),
+            prod_ba.allows(c),
+            "Product commutativity violated at {:?}",
+            c.raw
+        );
+    }
+
+    // Identity: A × ⊤ = A
+    let prod_with_universal = ComposedField::new(
+        build_field_a(),
+        IdentityField::Universal,
+        CompositionOp::Product,
+    );
+    assert_eq!(
+        prod_with_universal.allows(&coord(2, 1, 0)),
+        build_field_a().allows(&coord(2, 1, 0)),
+        "A × ⊤ should equal A"
+    );
+    assert_eq!(
+        prod_with_universal.allows(&coord(3, 1, 0)),
+        build_field_a().allows(&coord(3, 1, 0)),
+        "A × ⊤ should equal A"
+    );
+}
+
+// ==================== TEST 7: NESTED COMPOSITION ====================
+
+fn test_nested_composition() {
+    let fa = build_field_a();
+    let fb = build_field_b();
+    let fc = build_field_c();
+
+    // (A ∪ B) ∩ C
+    let nested = intersection(union(fa.clone(), fb.clone()), fc.clone());
+
+    assert!(
+        nested.allows(&coord(2, 1, 2)),
+        "Nested (A∪B)∩C should allow (2,1,2)"
+    );
+    assert!(
+        nested.allows(&coord(2, 10, 2)),
+        "Nested (A∪B)∩C should allow (2,10,2) because A∪B allows it"
+    );
+    assert!(
+        !nested.allows(&coord(3, 1, 5)),
+        "Nested (A∪B)∩C should reject (3,1,5) because C rejects"
+    );
+
+    // ((A ∩ B) ∩ C) = A ∩ B ∩ C
+    let triple_inter = intersection(intersection(fa.clone(), fb.clone()), fc.clone());
+    assert!(
+        triple_inter.allows(&coord(2, 1, 2)),
+        "Triple intersection should allow (2,1,2)"
+    );
+    assert!(
+        !triple_inter.allows(&coord(3, 1, 2)),
+        "Triple intersection should reject (3,1,2) because A rejects"
+    );
+    assert!(
+        !triple_inter.allows(&coord(2, 10, 2)),
+        "Triple intersection should reject (2,10,2) because B rejects"
+    );
+    assert!(
+        !triple_inter.allows(&coord(2, 1, 5)),
+        "Triple intersection should reject (2,1,5) because C rejects"
+    );
+}
+
+// ==================== TEST 8: COMPOSITION CHANGES ADMISSIBILITY ====================
+
+fn test_admissibility_composition() {
+    let fa = build_field_a();
+    let fb = build_field_b();
+    let fc = build_field_c();
+
+    // Narrow inquiry: where ALL three constraints hold
+    let narrow = intersection(intersection(fa.clone(), fb.clone()), fc.clone());
+
+    // Broad inquiry: where ANY constraint holds
+    let broad = union(union(fa.clone(), fb.clone()), fc.clone());
+
+    let coord_valid = coord(2, 1, 2);
+    assert!(narrow.allows(&coord_valid), "Narrow should allow (2,1,2)");
+    assert!(broad.allows(&coord_valid), "Broad should allow (2,1,2)");
+
+    let coord_all_violate = coord(3, 10, 5);
+    assert!(
+        !narrow.allows(&coord_all_violate),
+        "Narrow should reject (3,10,5)"
+    );
+    assert!(
+        !broad.allows(&coord_all_violate),
+        "Broad should reject (3,10,5)"
+    );
+
+    let coord_only_a = coord(2, 10, 5);
+    assert!(
+        !narrow.allows(&coord_only_a),
+        "Narrow should reject (2,10,5)"
+    );
+    assert!(
+        broad.allows(&coord_only_a),
+        "Broad should allow (2,10,5) — A allows"
+    );
+
+    let coord_only_b = coord(3, 3, 5);
+    assert!(
+        !narrow.allows(&coord_only_b),
+        "Narrow should reject (3,3,5)"
+    );
+    assert!(
+        broad.allows(&coord_only_b),
+        "Broad should allow (3,3,5) — B allows"
+    );
+
+    println!(
+        "  Same coord (2,10,5): Narrow={}, Broad={}",
+        narrow.allows(&coord_only_a),
+        broad.allows(&coord_only_a)
+    );
+    println!(
+        "  Same coord (3,3,5):  Narrow={}, Broad={}",
+        narrow.allows(&coord_only_b),
+        broad.allows(&coord_only_b)
+    );
+    println!("  → Different compositions of the same Fields produce");
+    println!("    different admissibility from the same coordinate space.");
+}
+
+// ==================== TEST 9: EXPRESSION DESCRIPTION ====================
+
+fn test_expression_description() {
+    let composed = union(build_field_a(), build_field_b());
+    let desc = composed.describe();
+    assert!(desc.contains('\u{222A}'), "Should contain union symbol");
+    println!("  Expression: {}", desc);
+
+    let nested = intersection(union(build_field_a(), build_field_b()), build_field_c());
+    let nested_desc = nested.describe();
+    assert!(
+        nested_desc.contains('\u{222A}') && nested_desc.contains('\u{2229}'),
+        "Should contain both operators"
+    );
+    println!("  Nested:     {}", nested_desc);
+
+    let with_id = union(IdentityField::Empty, build_field_a());
+    let id_desc = with_id.describe();
+    assert!(id_desc.contains('\u{2205}'), "Should contain empty symbol");
+    println!("  Identity:   {}", id_desc);
+}

--- a/poc/standard/crates/field-synthesis/src/main.rs
+++ b/poc/standard/crates/field-synthesis/src/main.rs
@@ -5,8 +5,7 @@
 //!
 //! ## Structure
 //!
-//! - Algebraic laws (tests 1–11): commutativity, associativity, distributivity, etc.
-//! - `test_compose_observe`: the bridge from composed Fields to the observation pipeline.
+//! - Algebraic laws (tests 1–12): commutativity, associativity, distributivity, etc.
 //! - `Scenario` module: domain-specific scenarios demonstrating composition with
 //!   heterogeneous axes — time, space, temperature, sensor identity, etc.
 //!
@@ -17,7 +16,6 @@ use ssccs_examples::{CoordinateSumProjector, EvenConstraint, RangeConstraint};
 use ssccs_field_synthesis::{IdentityField, compose_observe, intersection, product, union};
 
 mod scenarios;
-use scenarios::Scenario;
 
 fn main() {
     println!("=== Field Synthesis: Composition Algebra ===\n");
@@ -44,15 +42,14 @@ fn main() {
     for (name, test_fn) in &laws {
         print!("  {} ... ", name);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(test_fn));
-        if result.is_ok() {
+        let (ok, msg) = unwind_result(result);
+        if ok {
             println!("PASSED");
             passed += 1;
         } else {
             println!("FAILED");
-            if let Err(e) = result {
-                if let Some(m) = e.downcast_ref::<&str>() {
-                    println!("    Reason: {}", m);
-                }
+            if let Some(m) = msg {
+                println!("    Reason: {}", m);
             }
             failed += 1;
         }
@@ -62,17 +59,14 @@ fn main() {
     for s in scenarios::registry() {
         print!("  Scenario: {} ... ", s.name());
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| s.run()));
-        if result.is_ok() {
+        let (ok, msg) = unwind_result(result);
+        if ok {
             println!("PASSED");
             passed += 1;
         } else {
             println!("FAILED");
-            if let Err(e) = result {
-                if let Some(m) = e.downcast_ref::<&str>() {
-                    println!("    Reason: {}", m);
-                } else if let Some(m) = e.downcast_ref::<String>() {
-                    println!("    Reason: {}", m);
-                }
+            if let Some(m) = msg {
+                println!("    Reason: {}", m);
             }
             failed += 1;
         }
@@ -85,6 +79,19 @@ fn main() {
     );
     if failed > 0 {
         std::process::exit(1);
+    }
+}
+
+fn unwind_result(result: Result<(), Box<dyn std::any::Any + Send>>) -> (bool, Option<String>) {
+    match result {
+        Ok(()) => (true, None),
+        Err(e) => {
+            let msg = e
+                .downcast_ref::<&str>()
+                .map(|s| s.to_string())
+                .or_else(|| e.downcast_ref::<String>().cloned());
+            (false, msg)
+        }
     }
 }
 
@@ -103,13 +110,11 @@ fn field_a() -> Field {
     f.add_constraint(EvenConstraint::new(0));
     f
 }
-
 fn field_b() -> Field {
     let mut f = Field::new();
     f.add_constraint(RangeConstraint::new(1, 0, 5));
     f
 }
-
 fn field_c() -> Field {
     let mut f = Field::new();
     f.add_constraint(RangeConstraint::new(2, 0, 3));
@@ -122,11 +127,9 @@ fn test_identity() {
     let u = union(field_a(), IdentityField::Empty);
     assert!(u.allows(&coord(2, 1, 0)));
     assert!(!u.allows(&coord(3, 1, 0)));
-
     let i = intersection(field_a(), IdentityField::Universal);
     assert!(i.allows(&coord(2, 1, 0)));
     assert!(!i.allows(&coord(3, 1, 0)));
-
     assert!(!union(IdentityField::Empty, IdentityField::Empty).allows(&coord(0, 0, 0)));
     assert!(
         intersection(IdentityField::Universal, IdentityField::Universal)
@@ -260,11 +263,11 @@ fn test_admissibility() {
 
 fn test_description() {
     let d = union(field_a(), field_b()).describe();
-    assert!(d.contains('∪'));
+    assert!(d.contains('\u{222A}'));
     let nd = intersection(union(field_a(), field_b()), field_c()).describe();
-    assert!(nd.contains('∪') && nd.contains('∩'));
+    assert!(nd.contains('\u{222A}') && nd.contains('\u{2229}'));
     let id = union(IdentityField::Empty, field_a()).describe();
-    assert!(id.contains('∅'));
+    assert!(id.contains('\u{2205}'));
     println!("  Expression: {}", d);
     println!("  Nested:     {}", nd);
     println!("  Identity:   {}", id);
@@ -278,19 +281,22 @@ fn test_transition() {
     y.add_transition(coord(0, 0, 0), coord(2, 0, 0), 0.8);
     y.add_transition(coord(0, 0, 0), coord(3, 0, 0), 1.0);
     let o = coord(0, 0, 0);
-    assert_eq!(union(x.clone(), y.clone()).transition_targets(&o).len(), 3);
+    let ut = union(x.clone(), y.clone());
+    assert_eq!(ut.transition_targets(&o).len(), 3);
     let it = intersection(x.clone(), y.clone()).transition_targets(&o);
     assert_eq!(it.len(), 1);
     assert!(it.contains(&coord(2, 0, 0)));
     println!(
-        "  X∪Y: {:?}",
-        union(x, y)
-            .transition_targets(&o)
+        "  X\u{222A}Y: {:?}",
+        ut.transition_targets(&o)
             .iter()
             .map(|c| &c.raw)
             .collect::<Vec<_>>()
     );
-    println!("  X∩Y: {:?}", it.iter().map(|c| &c.raw).collect::<Vec<_>>());
+    println!(
+        "  X\u{2229}Y: {:?}",
+        it.iter().map(|c| &c.raw).collect::<Vec<_>>()
+    );
 }
 
 fn test_idempotence() {
@@ -312,10 +318,7 @@ fn test_compose_observe() {
     assert_eq!(compose_observe(&narrow, &projector, &seg), Some(5));
     assert!(compose_observe(&narrow, &projector, &Segment::new(coord(3, 10, 5))).is_none());
     assert!(compose_observe(&narrow, &projector, &Segment::new(coord(2, 10, 5))).is_none());
-    println!(
-        "  A∩B∩C at (2,1,2): {:?}",
-        compose_observe(&narrow, &projector, &seg)
-    );
-    println!("  A∩B∩C at (3,10,5): None");
-    println!("  → Observation through composed Fields is structurally real.");
+    println!("  A\u{2229}B\u{2229}C at (2,1,2): Some(5)");
+    println!("  A\u{2229}B\u{2229}C at (3,10,5): None");
+    println!("  \u{2192} Observation through composed Fields is structurally real.");
 }

--- a/poc/standard/crates/field-synthesis/src/main.rs
+++ b/poc/standard/crates/field-synthesis/src/main.rs
@@ -8,40 +8,31 @@
 //! The SSCCS philosophy establishes that "the manner in which we combine questions
 //! becomes a form of epistemology":
 //!
-//! - **Union (∪)**: Broaden the inquiry — combine Fields so that a coordinate is
-//!   admissible if either Field allows it.
-//! - **Intersection (∩)**: Narrow the focus — a coordinate is admissible only if
-//!   both Fields allow it.
-//! - **Product (×)**: Independent parallel investigation — each Field constrains
-//!   the same coordinate space independently, and all must agree.
-//!
-//! This experiment validates that these operations behave as a proper algebra:
-//! commutativity, associativity, identity elements, absorption, and distributivity,
-//! then demonstrates composition with actual constraints to show that the composed
-//! Field changes what is admissible.
+//! - **Union (∪)**: Broadens inquiry — admissible if either Field allows.
+//! - **Intersection (∩)**: Narrows focus — admissible only if both allow.
+//! - **Product (×)**: Parallel independent investigation — each Field governs
+//!   a disjoint axis partition.
 
-use ssccs_core::{Field, SpaceCoordinates};
-use ssccs_examples::{EvenConstraint, RangeConstraint};
-use ssccs_field_synthesis::{ComposedField, CompositionOp, IdentityField, intersection, union};
+use ssccs_core::{Field, Segment, SpaceCoordinates};
+use ssccs_examples::{CoordinateSumProjector, EvenConstraint, RangeConstraint};
+use ssccs_field_synthesis::{IdentityField, compose_observe, intersection, product, union};
 
 fn main() {
     println!("=== Field Synthesis: Composition Algebra ===\n");
 
     let tests: Vec<(&str, fn())> = vec![
-        ("1. Identity Elements", test_identity_elements),
+        ("1. Identity Elements", test_identity),
         ("2. Commutativity", test_commutativity),
         ("3. Associativity", test_associativity),
         ("4. Absorption", test_absorption),
         ("5. Distributivity", test_distributivity),
-        ("6. Product Semantics", test_product_semantics),
-        ("7. Nested Composition", test_nested_composition),
-        (
-            "8. Composition Changes Admissibility",
-            test_admissibility_composition,
-        ),
-        ("9. Expression Description", test_expression_description),
-        ("10. Transition Composition", test_transition_composition),
+        ("6. Product Semantics", test_product),
+        ("7. Nested Composition", test_nested),
+        ("8. Admissibility", test_admissibility),
+        ("9. Expression Description", test_description),
+        ("10. Transition Composition", test_transition),
         ("11. Idempotence", test_idempotence),
+        ("12. compose_observe Bridge", test_compose_observe),
     ];
 
     let mut passed = 0u32;
@@ -57,10 +48,10 @@ fn main() {
             }
             Err(e) => {
                 println!("FAILED");
-                if let Some(msg) = e.downcast_ref::<&str>() {
-                    println!("    Reason: {}", msg);
-                } else if let Some(msg) = e.downcast_ref::<String>() {
-                    println!("    Reason: {}", msg);
+                if let Some(m) = e.downcast_ref::<&str>() {
+                    println!("    Reason: {}", m);
+                } else if let Some(m) = e.downcast_ref::<String>() {
+                    println!("    Reason: {}", m);
                 }
                 failed += 1;
             }
@@ -78,125 +69,76 @@ fn main() {
     }
 }
 
-// ==================== TEST FIELD CONSTRUCTORS ====================
+fn coord(x: i64, y: i64, z: i64) -> SpaceCoordinates {
+    SpaceCoordinates::new(vec![x, y, z])
+}
+fn coord_1d(x: i64) -> SpaceCoordinates {
+    SpaceCoordinates::new(vec![x])
+}
 
-fn build_field_a() -> Field {
+fn field_a() -> Field {
     let mut f = Field::new();
     f.add_constraint(RangeConstraint::new(0, 0, 10));
     f.add_constraint(EvenConstraint::new(0));
     f
 }
 
-fn build_field_b() -> Field {
+fn field_b() -> Field {
     let mut f = Field::new();
     f.add_constraint(RangeConstraint::new(1, 0, 5));
     f
 }
 
-fn build_field_c() -> Field {
+fn field_c() -> Field {
     let mut f = Field::new();
     f.add_constraint(RangeConstraint::new(2, 0, 3));
     f
 }
 
-// ==================== COORDINATE HELPERS ====================
+// ==================== TESTS ====================
 
-fn coord(x: i64, y: i64, z: i64) -> SpaceCoordinates {
-    SpaceCoordinates::new(vec![x, y, z])
-}
+fn test_identity() {
+    let u = union(field_a(), IdentityField::Empty);
+    assert!(u.allows(&coord(2, 1, 0)));
+    assert!(!u.allows(&coord(3, 1, 0)));
 
-// ==================== TEST 1: IDENTITY ELEMENTS ====================
+    let i = intersection(field_a(), IdentityField::Universal);
+    assert!(i.allows(&coord(2, 1, 0)));
+    assert!(!i.allows(&coord(3, 1, 0)));
 
-fn test_identity_elements() {
-    // Union identity: A ∪ ∅ = A
-    let union_with_empty = union(build_field_a(), IdentityField::Empty);
+    assert!(!union(IdentityField::Empty, IdentityField::Empty).allows(&coord(0, 0, 0)));
     assert!(
-        union_with_empty.allows(&coord(2, 1, 0)),
-        "Union with empty should allow what A allows"
-    );
-    assert!(
-        !union_with_empty.allows(&coord(3, 1, 0)),
-        "Union with empty should reject what A rejects"
-    );
-    assert!(
-        !union_with_empty.allows(&coord(12, 1, 0)),
-        "Union with empty should reject out-of-range for A"
-    );
-
-    // Intersection identity: A ∩ ⊤ = A
-    let inter_with_universal = intersection(build_field_a(), IdentityField::Universal);
-    assert!(
-        inter_with_universal.allows(&coord(2, 1, 0)),
-        "Intersection with universal should allow what A allows"
-    );
-    assert!(
-        !inter_with_universal.allows(&coord(3, 1, 0)),
-        "Intersection with universal should reject what A rejects"
-    );
-
-    // Empty union empty = empty
-    let empty_empty = union(IdentityField::Empty, IdentityField::Empty);
-    assert!(
-        !empty_empty.allows(&coord(0, 0, 0)),
-        "Empty ∪ Empty should reject all coordinates"
-    );
-
-    // Universal intersected with universal = universal
-    let uni_uni = intersection(IdentityField::Universal, IdentityField::Universal);
-    assert!(
-        uni_uni.allows(&coord(999, -1, 100)),
-        "Universal ∩ Universal should allow everything"
+        intersection(IdentityField::Universal, IdentityField::Universal)
+            .allows(&coord(999, -1, 100))
     );
 }
-
-// ==================== TEST 2: COMMUTATIVITY ====================
 
 fn test_commutativity() {
-    let a_union_b = union(build_field_a(), build_field_b());
-    let b_union_a = union(build_field_b(), build_field_a());
-
-    let test_coords = vec![
+    let tests = [
         coord(2, 1, 0),
         coord(2, 10, 0),
         coord(3, 1, 0),
         coord(3, 10, 0),
         coord(4, 3, 5),
     ];
-
-    for c in &test_coords {
-        assert_eq!(
-            a_union_b.allows(c),
-            b_union_a.allows(c),
-            "Union commutativity violated at {:?}",
-            c.raw
-        );
+    let ab = union(field_a(), field_b());
+    let ba = union(field_b(), field_a());
+    for c in &tests {
+        assert_eq!(ab.allows(c), ba.allows(c));
     }
 
-    let a_inter_b = intersection(build_field_a(), build_field_b());
-    let b_inter_a = intersection(build_field_b(), build_field_a());
-
-    for c in &test_coords {
-        assert_eq!(
-            a_inter_b.allows(c),
-            b_inter_a.allows(c),
-            "Intersection commutativity violated at {:?}",
-            c.raw
-        );
+    let ab = intersection(field_a(), field_b());
+    let ba = intersection(field_b(), field_a());
+    for c in &tests {
+        assert_eq!(ab.allows(c), ba.allows(c));
     }
 }
 
-// ==================== TEST 3: ASSOCIATIVITY ====================
-
 fn test_associativity() {
-    let fa = build_field_a();
-    let fb = build_field_b();
-    let fc = build_field_c();
-
-    // Union: (A ∪ B) ∪ C = A ∪ (B ∪ C)
-    let left_union = union(union(fa.clone(), fb.clone()), fc.clone());
-    let right_union = union(fa.clone(), union(fb.clone(), fc.clone()));
-
-    let test_coords = vec![
+    let a = field_a();
+    let b = field_b();
+    let c = field_c();
+    let tests = [
         coord(2, 1, 1),
         coord(3, 1, 1),
         coord(2, 10, 1),
@@ -204,80 +146,46 @@ fn test_associativity() {
         coord(3, 10, 5),
         coord(4, 2, 2),
     ];
-
-    for c in &test_coords {
-        assert_eq!(
-            left_union.allows(c),
-            right_union.allows(c),
-            "Union associativity violated at {:?}",
-            c.raw
-        );
+    let l = union(union(a.clone(), b.clone()), c.clone());
+    let r = union(a.clone(), union(b.clone(), c.clone()));
+    for t in &tests {
+        assert_eq!(l.allows(t), r.allows(t));
     }
 
-    // Intersection: (A ∩ B) ∩ C = A ∩ (B ∩ C)
-    let left_inter = intersection(intersection(fa.clone(), fb.clone()), fc.clone());
-    let right_inter = intersection(fa.clone(), intersection(fb.clone(), fc.clone()));
-
-    for c in &test_coords {
-        assert_eq!(
-            left_inter.allows(c),
-            right_inter.allows(c),
-            "Intersection associativity violated at {:?}",
-            c.raw
-        );
+    let l = intersection(intersection(a.clone(), b.clone()), c.clone());
+    let r = intersection(a.clone(), intersection(b.clone(), c.clone()));
+    for t in &tests {
+        assert_eq!(l.allows(t), r.allows(t));
     }
 }
 
-// ==================== TEST 4: ABSORPTION ====================
-
 fn test_absorption() {
-    let fa = build_field_a();
-    let fb = build_field_b();
-
-    let a_union_a_inter_b = union(fa.clone(), intersection(fa.clone(), fb.clone()));
-    let test_coords = vec![
+    let a = field_a();
+    let b = field_b();
+    let tests = [
         coord(2, 1, 0),
         coord(2, 10, 0),
         coord(3, 1, 0),
         coord(3, 10, 0),
     ];
 
-    for c in &test_coords {
-        assert_eq!(
-            a_union_a_inter_b.allows(c),
-            fa.allows(c),
-            "Absorption law 1 violated at {:?}: A ∪ (A ∩ B) should equal A",
-            c.raw
-        );
+    let la = union(a.clone(), intersection(a.clone(), b.clone()));
+    for t in &tests {
+        assert_eq!(la.allows(t), a.allows(t));
     }
 
-    let a_inter_a_union_b = intersection(fa.clone(), union(fa, fb));
-    let fa2 = build_field_a();
-
-    for c in &test_coords {
-        assert_eq!(
-            a_inter_a_union_b.allows(c),
-            fa2.allows(c),
-            "Absorption law 2 violated at {:?}: A ∩ (A ∪ B) should equal A",
-            c.raw
-        );
+    let la = intersection(a.clone(), union(a, b));
+    let a2 = field_a();
+    for t in &tests {
+        assert_eq!(la.allows(t), a2.allows(t));
     }
 }
 
-// ==================== TEST 5: DISTRIBUTIVITY ====================
-
 fn test_distributivity() {
-    let fa = build_field_a();
-    let fb = build_field_b();
-    let fc = build_field_c();
-
-    let a_inter_b_union_c = intersection(fa.clone(), union(fb.clone(), fc.clone()));
-    let a_inter_b_union_a_inter_c = union(
-        intersection(fa.clone(), fb.clone()),
-        intersection(fa.clone(), fc.clone()),
-    );
-
-    let test_coords = vec![
+    let a = field_a();
+    let b = field_b();
+    let c = field_c();
+    let tests = [
         coord(2, 1, 1),
         coord(3, 1, 1),
         coord(2, 10, 1),
@@ -285,322 +193,136 @@ fn test_distributivity() {
         coord(2, 10, 5),
         coord(4, 2, 2),
     ];
-
-    for c in &test_coords {
-        assert_eq!(
-            a_inter_b_union_c.allows(c),
-            a_inter_b_union_a_inter_c.allows(c),
-            "Distributivity violated at {:?}: A ∩ (B ∪ C) = (A ∩ B) ∪ (A ∩ C)",
-            c.raw
-        );
+    let lhs = intersection(a.clone(), union(b.clone(), c.clone()));
+    let rhs = union(
+        intersection(a.clone(), b.clone()),
+        intersection(a.clone(), c.clone()),
+    );
+    for t in &tests {
+        assert_eq!(lhs.allows(t), rhs.allows(t));
     }
 }
 
-// ==================== TEST 6: PRODUCT SEMANTICS ====================
+fn test_product() {
+    let mut fa = Field::new();
+    fa.add_constraint(RangeConstraint::new(0, 0, 10));
+    fa.add_constraint(EvenConstraint::new(0));
 
-fn test_product_semantics() {
-    // Product: both Fields check the same coordinate space independently.
-    let prod = ComposedField::new(build_field_a(), build_field_b(), CompositionOp::Product);
-
-    // Field A: axis[0] even and in [0,10]; Field B: axis[1] in [0,5]
-    let coord_valid = coord(2, 3, 0);
-    let coord_a_rejects = coord(3, 3, 0);
-    let coord_b_rejects = coord(2, 10, 0);
-
-    assert!(
-        prod.allows(&coord_valid),
-        "Product should allow valid coordinate"
-    );
-    assert!(
-        !prod.allows(&coord_a_rejects),
-        "Product should reject when A rejects"
-    );
-    assert!(
-        !prod.allows(&coord_b_rejects),
-        "Product should reject when B rejects"
-    );
-
-    // Product is commutative: A × B = B × A
-    let prod_ba = ComposedField::new(build_field_b(), build_field_a(), CompositionOp::Product);
-    for c in &[
-        coord(2, 3, 0),
-        coord(3, 3, 0),
-        coord(2, 10, 0),
-        coord(11, 6, 0),
-    ] {
-        assert_eq!(
-            prod.allows(c),
-            prod_ba.allows(c),
-            "Product commutativity violated at {:?}",
-            c.raw
-        );
-    }
-
-    // Identity: A × ⊤ = A
-    let prod_with_universal = ComposedField::new(
-        build_field_a(),
-        IdentityField::Universal,
-        CompositionOp::Product,
-    );
-    assert_eq!(
-        prod_with_universal.allows(&coord(2, 1, 0)),
-        build_field_a().allows(&coord(2, 1, 0)),
-        "A × ⊤ should equal A"
-    );
-    assert_eq!(
-        prod_with_universal.allows(&coord(3, 1, 0)),
-        build_field_a().allows(&coord(3, 1, 0)),
-        "A × ⊤ should equal A"
-    );
+    let pa = product(fa.clone(), IdentityField::Unit, 1);
+    assert!(pa.allows(&coord_1d(2)));
+    assert!(!pa.allows(&coord_1d(3)));
+    assert!(!pa.allows(&coord_1d(12)));
 }
 
-// ==================== TEST 7: NESTED COMPOSITION ====================
+fn test_nested() {
+    let a = field_a();
+    let b = field_b();
+    let c = field_c();
+    let n = intersection(union(a.clone(), b.clone()), c.clone());
+    assert!(n.allows(&coord(2, 1, 2)));
+    assert!(n.allows(&coord(2, 10, 2)));
+    assert!(!n.allows(&coord(3, 1, 5)));
 
-fn test_nested_composition() {
-    let fa = build_field_a();
-    let fb = build_field_b();
-    let fc = build_field_c();
-
-    // (A ∪ B) ∩ C
-    let nested = intersection(union(fa.clone(), fb.clone()), fc.clone());
-
-    assert!(
-        nested.allows(&coord(2, 1, 2)),
-        "Nested (A∪B)∩C should allow (2,1,2)"
-    );
-    assert!(
-        nested.allows(&coord(2, 10, 2)),
-        "Nested (A∪B)∩C should allow (2,10,2) because A∪B allows it"
-    );
-    assert!(
-        !nested.allows(&coord(3, 1, 5)),
-        "Nested (A∪B)∩C should reject (3,1,5) because C rejects"
-    );
-
-    // ((A ∩ B) ∩ C) = A ∩ B ∩ C
-    let triple_inter = intersection(intersection(fa.clone(), fb.clone()), fc.clone());
-    assert!(
-        triple_inter.allows(&coord(2, 1, 2)),
-        "Triple intersection should allow (2,1,2)"
-    );
-    assert!(
-        !triple_inter.allows(&coord(3, 1, 2)),
-        "Triple intersection should reject (3,1,2) because A rejects"
-    );
-    assert!(
-        !triple_inter.allows(&coord(2, 10, 2)),
-        "Triple intersection should reject (2,10,2) because B rejects"
-    );
-    assert!(
-        !triple_inter.allows(&coord(2, 1, 5)),
-        "Triple intersection should reject (2,1,5) because C rejects"
-    );
+    let t = intersection(intersection(a.clone(), b.clone()), c.clone());
+    assert!(t.allows(&coord(2, 1, 2)));
+    assert!(!t.allows(&coord(3, 1, 2)));
+    assert!(!t.allows(&coord(2, 10, 2)));
+    assert!(!t.allows(&coord(2, 1, 5)));
 }
 
-// ==================== TEST 8: COMPOSITION CHANGES ADMISSIBILITY ====================
+fn test_admissibility() {
+    let a = field_a();
+    let b = field_b();
+    let c = field_c();
+    let narrow = intersection(intersection(a.clone(), b.clone()), c.clone());
+    let broad = union(union(a.clone(), b.clone()), c.clone());
 
-fn test_admissibility_composition() {
-    let fa = build_field_a();
-    let fb = build_field_b();
-    let fc = build_field_c();
+    assert!(narrow.allows(&coord(2, 1, 2)));
+    assert!(!narrow.allows(&coord(3, 10, 5)));
+    assert!(!narrow.allows(&coord(2, 10, 5)));
+    assert!(broad.allows(&coord(2, 10, 5)));
 
-    // Narrow inquiry: where ALL three constraints hold
-    let narrow = intersection(intersection(fa.clone(), fb.clone()), fc.clone());
-
-    // Broad inquiry: where ANY constraint holds
-    let broad = union(union(fa.clone(), fb.clone()), fc.clone());
-
-    let coord_valid = coord(2, 1, 2);
-    assert!(narrow.allows(&coord_valid), "Narrow should allow (2,1,2)");
-    assert!(broad.allows(&coord_valid), "Broad should allow (2,1,2)");
-
-    let coord_all_violate = coord(3, 10, 5);
-    assert!(
-        !narrow.allows(&coord_all_violate),
-        "Narrow should reject (3,10,5)"
-    );
-    assert!(
-        !broad.allows(&coord_all_violate),
-        "Broad should reject (3,10,5)"
-    );
-
-    let coord_only_a = coord(2, 10, 5);
-    assert!(
-        !narrow.allows(&coord_only_a),
-        "Narrow should reject (2,10,5)"
-    );
-    assert!(
-        broad.allows(&coord_only_a),
-        "Broad should allow (2,10,5) — A allows"
-    );
-
-    let coord_only_b = coord(3, 3, 5);
-    assert!(
-        !narrow.allows(&coord_only_b),
-        "Narrow should reject (3,3,5)"
-    );
-    assert!(
-        broad.allows(&coord_only_b),
-        "Broad should allow (3,3,5) — B allows"
-    );
-
-    println!(
-        "  Same coord (2,10,5): Narrow={}, Broad={}",
-        narrow.allows(&coord_only_a),
-        broad.allows(&coord_only_a)
-    );
-    println!(
-        "  Same coord (3,3,5):  Narrow={}, Broad={}",
-        narrow.allows(&coord_only_b),
-        broad.allows(&coord_only_b)
-    );
-    println!("  → Different compositions of the same Fields produce");
-    println!("    different admissibility from the same coordinate space.");
+    println!("  Same coord (2,10,5): Narrow=false, Broad=true");
 }
 
-// ==================== TEST 9: EXPRESSION DESCRIPTION ====================
-
-fn test_expression_description() {
-    let composed = union(build_field_a(), build_field_b());
-    let desc = composed.describe();
-    assert!(desc.contains('\u{222A}'), "Should contain union symbol");
-    println!("  Expression: {}", desc);
-
-    let nested = intersection(union(build_field_a(), build_field_b()), build_field_c());
-    let nested_desc = nested.describe();
-    assert!(
-        nested_desc.contains('\u{222A}') && nested_desc.contains('\u{2229}'),
-        "Should contain both operators"
-    );
-    println!("  Nested:     {}", nested_desc);
-
-    let with_id = union(IdentityField::Empty, build_field_a());
-    let id_desc = with_id.describe();
-    assert!(id_desc.contains('\u{2205}'), "Should contain empty symbol");
-    println!("  Identity:   {}", id_desc);
+fn test_description() {
+    let d = union(field_a(), field_b()).describe();
+    assert!(d.contains('∪'));
+    let nd = intersection(union(field_a(), field_b()), field_c()).describe();
+    assert!(nd.contains('∪') && nd.contains('∩'));
+    let id = union(IdentityField::Empty, field_a()).describe();
+    assert!(id.contains('∅'));
+    println!("  Expression: {}", d);
+    println!("  Nested:     {}", nd);
+    println!("  Identity:   {}", id);
 }
 
-// ==================== TEST 10: TRANSITION COMPOSITION ====================
+fn test_transition() {
+    let mut x = Field::new();
+    x.add_transition(coord(0, 0, 0), coord(1, 0, 0), 1.0);
+    x.add_transition(coord(0, 0, 0), coord(2, 0, 0), 0.5);
 
-fn test_transition_composition() {
-    // Build fields with transitions for composition testing
-    let mut field_x = Field::new();
-    field_x.add_transition(coord(0, 0, 0), coord(1, 0, 0), 1.0);
-    field_x.add_transition(coord(0, 0, 0), coord(2, 0, 0), 0.5);
+    let mut y = Field::new();
+    y.add_transition(coord(0, 0, 0), coord(2, 0, 0), 0.8);
+    y.add_transition(coord(0, 0, 0), coord(3, 0, 0), 1.0);
 
-    let mut field_y = Field::new();
-    field_y.add_transition(coord(0, 0, 0), coord(2, 0, 0), 0.8);
-    field_y.add_transition(coord(0, 0, 0), coord(3, 0, 0), 1.0);
+    let o = coord(0, 0, 0);
 
-    let origin = coord(0, 0, 0);
+    let ut = union(x.clone(), y.clone()).transition_targets(&o);
+    assert_eq!(ut.len(), 3);
 
-    // Union: (X ∪ Y) at (0,0,0) → targets from both: [(1,0,0), (2,0,0), (3,0,0)]
-    let union_xy = union(field_x.clone(), field_y.clone());
-    let union_targets = union_xy.transition_targets(&origin);
-    assert!(
-        union_targets.contains(&coord(1, 0, 0)),
-        "Union should include (1,0,0) from X"
-    );
-    assert!(
-        union_targets.contains(&coord(2, 0, 0)),
-        "Union should include (2,0,0) from both"
-    );
-    assert!(
-        union_targets.contains(&coord(3, 0, 0)),
-        "Union should include (3,0,0) from Y"
-    );
-    assert_eq!(union_targets.len(), 3, "Union should have 3 unique targets");
-
-    // Intersection: (X ∩ Y) at (0,0,0) → targets common to both: [(2,0,0)]
-    let inter_xy = intersection(field_x.clone(), field_y.clone());
-    let inter_targets = inter_xy.transition_targets(&origin);
-    assert!(
-        inter_targets.contains(&coord(2, 0, 0)),
-        "Intersection should include (2,0,0) common to both"
-    );
-    assert_eq!(inter_targets.len(), 1, "Intersection should have 1 target");
-
-    // Product (no split): (X × Y) at (0,0,0) → targets common to both: [(2,0,0)]
-    let prod_xy = ComposedField::new(field_x.clone(), field_y.clone(), CompositionOp::Product);
-    let prod_targets = prod_xy.transition_targets(&origin);
-    assert!(
-        prod_targets.contains(&coord(2, 0, 0)),
-        "Product (no split) should include (2,0,0) common to both"
-    );
-    assert_eq!(
-        prod_targets.len(),
-        1,
-        "Product (no split) should have 1 target"
-    );
-
-    // Identity: ∅ has no transitions
-    let union_with_empty = union(field_x.clone(), IdentityField::Empty);
-    let empty_targets = union_with_empty.transition_targets(&origin);
-    assert_eq!(
-        empty_targets.len(),
-        2,
-        "Union with empty should retain all targets from X"
-    );
-    assert!(empty_targets.contains(&coord(1, 0, 0)));
-    assert!(empty_targets.contains(&coord(2, 0, 0)));
+    let it = intersection(x.clone(), y.clone()).transition_targets(&o);
+    assert_eq!(it.len(), 1);
+    assert!(it.contains(&coord(2, 0, 0)));
 
     println!(
-        "  X ∪ Y targets: {:?}",
-        union_targets.iter().map(|c| &c.raw).collect::<Vec<_>>()
+        "  X ∪ Y: {:?}",
+        ut.iter().map(|c| &c.raw).collect::<Vec<_>>()
     );
     println!(
-        "  X ∩ Y targets: {:?}",
-        inter_targets.iter().map(|c| &c.raw).collect::<Vec<_>>()
+        "  X ∩ Y: {:?}",
+        it.iter().map(|c| &c.raw).collect::<Vec<_>>()
     );
-    println!(
-        "  X × Y targets: {:?}",
-        prod_targets.iter().map(|c| &c.raw).collect::<Vec<_>>()
-    );
-    println!("  → Transition topology is preserved through Field composition.");
 }
-
-// ==================== TEST 11: IDEMPOTENCE ====================
 
 fn test_idempotence() {
-    // A ∪ A = A
-    let fa = build_field_a();
-    let a_union_a = union(fa.clone(), fa.clone());
-    let test_coords = vec![coord(2, 1, 0), coord(3, 1, 0), coord(12, 1, 0)];
-    for c in &test_coords {
-        assert_eq!(
-            a_union_a.allows(c),
-            fa.allows(c),
-            "A ∪ A should equal A at {:?}",
-            c.raw
-        );
+    let a = field_a();
+    let tests = [coord(2, 1, 0), coord(3, 1, 0), coord(12, 1, 0)];
+    for t in &tests {
+        assert_eq!(union(a.clone(), a.clone()).allows(t), a.allows(t));
+        assert_eq!(intersection(a.clone(), a.clone()).allows(t), a.allows(t));
     }
-
-    // A ∩ A = A
-    let a_inter_a = intersection(fa.clone(), fa.clone());
-    for c in &test_coords {
-        assert_eq!(
-            a_inter_a.allows(c),
-            fa.allows(c),
-            "A ∩ A should equal A at {:?}",
-            c.raw
-        );
-    }
-
-    // ∅ ∪ ∅ = ∅
-    let empty_empty = union(IdentityField::Empty, IdentityField::Empty);
+    assert!(!union(IdentityField::Empty, IdentityField::Empty).allows(&coord(0, 0, 0)));
     assert!(
-        !empty_empty.allows(&coord(0, 0, 0)),
-        "∅ ∪ ∅ should be empty"
+        intersection(IdentityField::Universal, IdentityField::Universal).allows(&coord(999, 0, 0))
     );
+}
 
-    // ⊤ ∩ ⊤ = ⊤
-    let uni_uni = intersection(IdentityField::Universal, IdentityField::Universal);
-    assert!(
-        uni_uni.allows(&coord(999, 0, 0)),
-        "⊤ ∩ ⊤ should be universal"
+fn test_compose_observe() {
+    let narrow = intersection(intersection(field_a(), field_b()), field_c());
+    let projector = CoordinateSumProjector;
+
+    let seg = Segment::new(coord(2, 1, 2));
+    let obs = compose_observe(&narrow, &projector, &seg);
+    assert_eq!(obs, Some(5));
+
+    let seg_bad = Segment::new(coord(3, 10, 5));
+    assert!(compose_observe(&narrow, &projector, &seg_bad).is_none());
+
+    let seg_partial = Segment::new(coord(2, 10, 5));
+    assert!(compose_observe(&narrow, &projector, &seg_partial).is_none());
+
+    println!(
+        "    A∩B∩C at (2,1,2): {:?}",
+        compose_observe(&narrow, &projector, &seg)
     );
-
-    println!("  A ∪ A = A, A ∩ A = A (verified across multiple coordinates)");
-    println!("  ∅ ∪ ∅ = ∅, ⊤ ∩ ⊤ = ⊤");
-    println!("  → All idempotence laws satisfied.");
+    println!(
+        "    A∩B∩C at (3,10,5): {:?}",
+        compose_observe(&narrow, &projector, &seg_bad)
+    );
+    println!(
+        "    A∩B∩C at (2,10,5): {:?}",
+        compose_observe(&narrow, &projector, &seg_partial)
+    );
+    println!("  → Observation through composed Fields is structurally real.");
 }

--- a/poc/standard/crates/field-synthesis/src/scenarios/mod.rs
+++ b/poc/standard/crates/field-synthesis/src/scenarios/mod.rs
@@ -1,0 +1,183 @@
+use ssccs_core::{Field, Segment, SpaceCoordinates};
+use ssccs_examples::{CoordinateSumProjector, EvenConstraint, RangeConstraint};
+use ssccs_field_synthesis::{compose_observe, intersection, union};
+
+/// A self-contained demonstration that Field composition changes what is observable.
+pub trait Scenario {
+    fn name(&self) -> &'static str;
+    fn run(&self);
+}
+
+/// All registered scenarios.
+pub fn registry() -> Vec<Box<dyn Scenario>> {
+    vec![Box::new(Grid2D {}), Box::new(SensorTimeTemp {})]
+}
+
+// ==================== GRID 2D ====================
+
+struct Grid2D;
+
+impl Scenario for Grid2D {
+    fn name(&self) -> &'static str {
+        "Grid2D: Parity × Range"
+    }
+
+    fn run(&self) {
+        let mut p = Field::new();
+        p.add_constraint(EvenConstraint::new(0));
+        let mut q = Field::new();
+        q.add_constraint(RangeConstraint::new(1, 0, 1));
+
+        let segs: Vec<Segment> = (0..=2)
+            .flat_map(|y| (0..=2).map(move |x| Segment::new(SpaceCoordinates::new(vec![x, y]))))
+            .collect();
+        assert_eq!(segs.len(), 9);
+
+        let narrow = intersection(p.clone(), q.clone());
+        let narrow_count = segs
+            .iter()
+            .filter(|s| narrow.allows(s.coordinates()))
+            .count();
+        assert_eq!(narrow_count, 4);
+
+        let broad = union(p.clone(), q.clone());
+        let broad_count = segs
+            .iter()
+            .filter(|s| broad.allows(s.coordinates()))
+            .count();
+        assert_eq!(broad_count, 8);
+
+        let proj = CoordinateSumProjector;
+        let sums: Vec<i64> = segs
+            .iter()
+            .filter_map(|s| compose_observe(&narrow, &proj, s))
+            .collect();
+        assert_eq!(sums, vec![0, 2, 1, 3]);
+
+        let broad_sums: Vec<i64> = segs
+            .iter()
+            .filter_map(|s| compose_observe(&broad, &proj, s))
+            .collect();
+        assert_eq!(broad_sums.len(), 8);
+
+        println!("    axis[0]=parity  axis[1]=range  9-segment 2D space");
+        println!(
+            "    P∩Q (narrow): {} segments → sums: {:?}",
+            narrow_count, sums
+        );
+        println!("    P∪Q (broad):  {} segments", broad_count);
+    }
+}
+
+// ==================== SENSOR × TIME × TEMPERATURE ====================
+
+/// Heterogeneous axes — each carries a distinct physical meaning.
+///
+/// - axis[0]: time step   (0=early, 1=mid, 2=late)
+/// - axis[1]: sensor id   (0, 1)
+/// - axis[2]: temperature (0=low, 1=medium, 2=high)
+///
+/// Fields represent domain questions applied to this 3D observation space.
+struct SensorTimeTemp;
+
+impl Scenario for SensorTimeTemp {
+    fn name(&self) -> &'static str {
+        "Sensor×Time×Temperature"
+    }
+
+    fn run(&self) {
+        // ── axes ──
+        // time: 0..=2 (3 steps), sensor: 0..=1 (2 ids), temp: 0..=2 (3 bands)
+        // Total segments: 3 × 2 × 3 = 18
+
+        let segs: Vec<Segment> = (0..=2)
+            .flat_map(|t| {
+                (0..=1).flat_map(move |s| {
+                    (0..=2).map(move |c| Segment::new(SpaceCoordinates::new(vec![t, s, c])))
+                })
+            })
+            .collect();
+        assert_eq!(segs.len(), 18);
+
+        // ── domain Fields ──
+        // "early time"       : axis[0] ∈ [0, 1]
+        // "sensor 0 only"    : axis[1] = 0
+        // "high temperature" : axis[2] ∈ [2, 2]  (only band 2)
+
+        let mut early_time = Field::new();
+        early_time.add_constraint(RangeConstraint::new(0, 0, 1));
+
+        let mut sensor_zero = Field::new();
+        sensor_zero.add_constraint(RangeConstraint::new(1, 0, 0));
+
+        let mut high_temp = Field::new();
+        high_temp.add_constraint(RangeConstraint::new(2, 2, 2));
+
+        // ── inquiry compositions ──
+        // Narrow: early time ∧ sensor 0 ∧ high temp → very specific
+        let narrow = intersection(
+            intersection(early_time.clone(), sensor_zero.clone()),
+            high_temp.clone(),
+        );
+        // Broad: early time ∨ sensor 0 ∨ high temp → exploratory
+        let broad = union(
+            union(early_time.clone(), sensor_zero.clone()),
+            high_temp.clone(),
+        );
+        // Mixed: (early time ∧ sensor 0) ∨ high temp → relax temperature
+        let mixed = union(
+            intersection(early_time.clone(), sensor_zero.clone()),
+            high_temp.clone(),
+        );
+
+        let proj = CoordinateSumProjector;
+
+        let narrow_results: Vec<i64> = segs
+            .iter()
+            .filter_map(|s| compose_observe(&narrow, &proj, s))
+            .collect();
+        let broad_results: Vec<i64> = segs
+            .iter()
+            .filter_map(|s| compose_observe(&broad, &proj, s))
+            .collect();
+        let mixed_results: Vec<i64> = segs
+            .iter()
+            .filter_map(|s| compose_observe(&mixed, &proj, s))
+            .collect();
+
+        // Verify counts manually:
+        // Narrow: t∈{0,1} ∩ s=0 ∩ c=2 → 2×1×1 = 2
+        assert_eq!(narrow_results.len(), 2);
+        // Broad: NOT (t=2 ∧ s=1 ∧ c∈{0,1}) → 18 - 2 = 16
+        assert_eq!(broad_results.len(), 16);
+        // Mixed: (t∈{0,1} ∧ s=0) ∪ c=2 → 4 + (18-12) - 2 = 4+6-2 = 8
+        //   early_time ∩ sensor_zero: t∈{0,1}, s=0, c∈{0,1,2} → 2×1×3 = 6
+        //   high_temp: t∈{0,1,2}, s∈{0,1}, c=2 → 3×2×1 = 6
+        //   overlap: t∈{0,1}, s=0, c=2 → 2
+        //   union: 6+6-2 = 10
+        // Wait, let me recalculate.
+        // early_time ∩ sensor_zero: t∈{0,1}, s=0, ANY c → 2×1×3 = 6
+        // high_temp: ANY t, ANY s, c=2 → 3×2×1 = 6
+        // Overlap: t∈{0,1}, s=0, c=2 → 2×1×1 = 2
+        // mixed = 6 + 6 - 2 = 10
+        assert_eq!(mixed_results.len(), 10);
+
+        println!("    axes: time∈[0..2], sensor∈[0..1], temp∈[0..2]  (18 segments)");
+        println!(
+            "    early_time ∧ sensor₀ ∧ high_temp → {} segments → sums: {:?}",
+            narrow_results.len(),
+            narrow_results
+        );
+        println!(
+            "    early_time ∨ sensor₀ ∨ high_temp → {} segments",
+            broad_results.len()
+        );
+        println!(
+            "    (early_time ∧ sensor₀) ∨ high_temp → {} segments → sums: {:?}",
+            mixed_results.len(),
+            mixed_results
+        );
+        println!("    → Heterogeneous axes carry independent semantics.");
+        println!("    → Field composition changes inquiry without changing the space.");
+    }
+}


### PR DESCRIPTION
Implements the Field composition algebra as specified in Issue #7 (PoC Development Phase 2, Phase 1, Item 1).

Closes #31

## Changes

### `field-synthesis/src/lib.rs`
- Defines `CompositionOp` enum (Union, Intersection, Product) with identity elements
- Defines `IdentityField` (Empty, Universal, Unit) for algebraic identity laws
- Implements `ComposedField` struct with recursive expression tree (`ComposedExpr`)
- Implements `From` conversions for Field, IdentityField, and nested ComposedField
- Exports convenience functions: `union()`, `intersection()`, `product()`

### `field-synthesis/src/main.rs`
Nine algebraic property tests - all passing:

| # | Test | Property |
|---|------|----------|
| 1 | Identity Elements | A ∪ ∅ = A, A ∩ ⊤ = A |
| 2 | Commutativity | A ∪ B = B ∪ A, A ∩ B = B ∩ A |
| 3 | Associativity | (A ∪ B) ∪ C = A ∪ (B ∪ C) |
| 4 | Absorption | A ∪ (A ∩ B) = A, A ∩ (A ∪ B) = A |
| 5 | Distributivity | A ∩ (B ∪ C) = (A ∩ B) ∪ (A ∩ C) |
| 6 | Product Semantics | A × B = B × A, A × ⊤ = A |
| 7 | Nested Composition | Deep nesting: (A∪B)∩C, (A∩B)∩C |
| 8 | Admissibility | Narrow vs Broad inquiry, different results |
| 9 | Expression Description | Recursive expression string serialization |

### `field-synthesis/Cargo.toml`
- Added `ssccs-examples` dependency

## Verification
```
=== Field Synthesis: Composition Algebra ===
  1. Identity Elements ... PASSED
  ...
  9. Expression Description ... PASSED
Results: 9 passed, 0 failed out of 9 tests
```

## Related
- Sub-issue of #7 (PoC Development Phase 2)
- Documents the philosophy from: `docs/philosophy/index.qmd`