### PR TITLE
PR: refactor: remove TransitionMatrix::id_to_coords and unify to SegmentId-based API #41

### DIFF
--- a/poc/standard/crates/core/src/core.rs
+++ b/poc/standard/crates/core/src/core.rs
@@ -147,8 +147,6 @@ impl ConstraintSet {
 pub struct TransitionMatrix {
     /// from SegmentId → [(to SegmentId, weight)]
     edges: HashMap<SegmentId, Vec<(SegmentId, f64)>>,
-    /// Mapping from SegmentId to coordinates (for legacy API support)
-    id_to_coords: HashMap<SegmentId, SpaceCoordinates>,
 }
 
 impl TransitionMatrix {
@@ -156,66 +154,24 @@ impl TransitionMatrix {
         Self::default()
     }
 
-    /// Add a transition using SegmentIds (new preferred API).
-    /// Note: You must also store coordinates if you want to use legacy API later.
-    pub fn add_by_id(
-        &mut self,
-        from: SegmentId,
-        to: SegmentId,
-        weight: f64,
-        from_coords: Option<SpaceCoordinates>,
-        to_coords: Option<SpaceCoordinates>,
-    ) {
+    /// Add a transition using SegmentIds.
+    pub fn add(&mut self, from: SegmentId, to: SegmentId, weight: f64) {
         self.edges.entry(from).or_default().push((to, weight));
-        if let Some(coords) = from_coords {
-            self.id_to_coords.insert(from, coords);
-        }
-        if let Some(coords) = to_coords {
-            self.id_to_coords.insert(to, coords);
-        }
     }
 
-    /// Add a transition using coordinates (legacy API, converts to SegmentId internally).
-    pub fn add(&mut self, from: SpaceCoordinates, to: SpaceCoordinates, weight: f64) {
-        let from_id = segment_id_from_coords(&from);
-        let to_id = segment_id_from_coords(&to);
-
-        // Store coordinates for later lookup
-        self.id_to_coords.insert(from_id, from.clone());
-        self.id_to_coords.insert(to_id, to.clone());
-
-        self.edges.entry(from_id).or_default().push((to_id, weight));
-    }
-
-    /// Get transition targets from a SegmentId (new preferred API).
-    pub fn transitions_from_id(&self, from: &SegmentId) -> Vec<SegmentId> {
+    /// Get transition targets from a SegmentId.
+    pub fn transitions_from(&self, from: &SegmentId) -> Vec<SegmentId> {
         self.edges
             .get(from)
             .map(|v| v.iter().map(|(to, _)| *to).collect())
             .unwrap_or_default()
     }
 
-    /// Get transition targets from coordinates (legacy API).
-    pub fn transitions_from(&self, from: &SpaceCoordinates) -> Vec<SpaceCoordinates> {
-        let from_id = segment_id_from_coords(from);
-        self.transitions_from_id(&from_id)
-            .into_iter()
-            .filter_map(|segment_id| self.id_to_coords.get(&segment_id).cloned())
-            .collect()
-    }
-
-    /// Get weight between SegmentIds (new API).
-    pub fn get_weight_by_id(&self, from: &SegmentId, to: &SegmentId) -> Option<f64> {
+    /// Get weight between SegmentIds.
+    pub fn get_weight(&self, from: &SegmentId, to: &SegmentId) -> Option<f64> {
         self.edges
             .get(from)
             .and_then(|vec| vec.iter().find(|(t, _)| t == to).map(|(_, w)| *w))
-    }
-
-    /// Get weight between coordinates (legacy API).
-    pub fn get_weight(&self, from: &SpaceCoordinates, to: &SpaceCoordinates) -> Option<f64> {
-        let from_id = segment_id_from_coords(from);
-        let to_id = segment_id_from_coords(to);
-        self.get_weight_by_id(&from_id, &to_id)
     }
 }
 
@@ -238,8 +194,11 @@ impl Field {
     }
 
     /// Add a transition rule (from → to with weight).
+    /// Converts coordinates to SegmentIds internally.
     pub fn add_transition(&mut self, from: SpaceCoordinates, to: SpaceCoordinates, weight: f64) {
-        self.transitions.add(from, to, weight);
+        let from_id = segment_id_from_coords(&from);
+        let to_id = segment_id_from_coords(&to);
+        self.transitions.add(from_id, to_id, weight);
     }
 
     /// Check whether a coordinate is allowed by all current constraints.
@@ -247,9 +206,10 @@ impl Field {
         self.constraints.allows(coords)
     }
 
-    /// Return all transition targets from a given coordinate (defined by the field only).
-    pub fn transition_targets(&self, from: &SpaceCoordinates) -> Vec<SpaceCoordinates> {
-        self.transitions.transitions_from(from)
+    /// Return all transition target SegmentIds from a given coordinate (defined by the field only).
+    pub fn transition_targets(&self, from: &SpaceCoordinates) -> Vec<SegmentId> {
+        let from_id = segment_id_from_coords(from);
+        self.transitions.transitions_from(&from_id)
     }
 
     /// Describe the current constraints (for debugging).

--- a/poc/standard/crates/core/src/lib.rs
+++ b/poc/standard/crates/core/src/lib.rs
@@ -66,17 +66,23 @@ pub fn observe<P: Projector>(field: &Field, segment: &Segment, projector: &P) ->
     }
 }
 
-/// Compute all possible next coordinates from the current segment, taking into account
+/// Compute all possible next SegmentIds from the current segment, taking into account
 /// both the projector's interpretation of adjacency and the field's transition matrix,
 /// filtered by field constraints.
 pub fn possible_next_coordinates<P: Projector>(
     field: &Field,
     segment: &Segment,
     projector: &P,
-) -> Vec<SpaceCoordinates> {
+) -> Vec<SegmentId> {
     let current = segment.coordinates();
-    let mut candidates = projector.possible_next_coordinates(current);
+    let projector_candidates = projector.possible_next_coordinates(current);
+    let mut candidates: Vec<SegmentId> = projector_candidates
+        .into_iter()
+        .filter(|c| field.allows(c))
+        .map(|c| segment_id_from_coords(&c))
+        .collect();
     candidates.extend(field.transition_targets(current));
-    candidates.retain(|c| field.allows(c));
+    candidates.sort();
+    candidates.dedup();
     candidates
 }

--- a/poc/standard/crates/experiments/field/src/main.rs
+++ b/poc/standard/crates/experiments/field/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests the Field concept - mutable constraint substrate and transition topology.
 
-use ssccs_core::{Field, SpaceCoordinates, segment_id_from_coords};
+use ssccs_core::{segment_id_from_coords, Field, SpaceCoordinates};
 use ssccs_examples::{EvenConstraint, RangeConstraint};
 
 fn main() {

--- a/poc/standard/crates/experiments/field/src/main.rs
+++ b/poc/standard/crates/experiments/field/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests the Field concept - mutable constraint substrate and transition topology.
 
-use ssccs_core::{Field, SpaceCoordinates};
+use ssccs_core::{Field, SpaceCoordinates, segment_id_from_coords};
 use ssccs_examples::{EvenConstraint, RangeConstraint};
 
 fn main() {
@@ -69,11 +69,11 @@ fn test_field_concept() -> Result<(), String> {
         "- Transition targets: {:?}",
         transitions
             .iter()
-            .map(|c| c.raw.clone())
+            .map(|id| id.as_bytes())
             .collect::<Vec<_>>()
     );
 
-    if transitions.len() != 1 || transitions[0] != to_coords {
+    if transitions.len() != 1 || transitions[0] != segment_id_from_coords(&to_coords) {
         return Err("Transition should return the correct target coordinates".to_string());
     }
 

--- a/poc/standard/crates/experiments/observation/src/main.rs
+++ b/poc/standard/crates/experiments/observation/src/main.rs
@@ -58,7 +58,10 @@ fn test_observation_concept() -> Result<(), String> {
     println!("3. Possible next coordinates (filtered by field):");
     println!(
         "- {:?}",
-        next_coords.iter().map(|id| id.as_bytes()).collect::<Vec<_>>()
+        next_coords
+            .iter()
+            .map(|id| id.as_bytes())
+            .collect::<Vec<_>>()
     );
 
     Ok(())

--- a/poc/standard/crates/experiments/observation/src/main.rs
+++ b/poc/standard/crates/experiments/observation/src/main.rs
@@ -58,7 +58,7 @@ fn test_observation_concept() -> Result<(), String> {
     println!("3. Possible next coordinates (filtered by field):");
     println!(
         "- {:?}",
-        next_coords.iter().map(|c| c.raw[0]).collect::<Vec<_>>()
+        next_coords.iter().map(|id| id.as_bytes()).collect::<Vec<_>>()
     );
 
     Ok(())

--- a/poc/standard/crates/experiments/transition/src/main.rs
+++ b/poc/standard/crates/experiments/transition/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests the Transition Matrix - relational topology as weighted directed graph.
 
-use ssccs_core::{Field, SpaceCoordinates, segment_id_from_coords};
+use ssccs_core::{segment_id_from_coords, Field, SpaceCoordinates};
 
 fn main() {
     println!("Experiment: Transition Matrix                    ");

--- a/poc/standard/crates/experiments/transition/src/main.rs
+++ b/poc/standard/crates/experiments/transition/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests the Transition Matrix - relational topology as weighted directed graph.
 
-use ssccs_core::{Field, SpaceCoordinates};
+use ssccs_core::{Field, SpaceCoordinates, segment_id_from_coords};
 
 fn main() {
     println!("Experiment: Transition Matrix                    ");
@@ -37,7 +37,7 @@ fn test_transition_matrix() -> Result<(), String> {
     );
 
     for target in &targets {
-        println!("- {:?}", target.raw);
+        println!("- {:?}", target.as_bytes());
     }
 
     if targets.len() != 2 {
@@ -45,10 +45,10 @@ fn test_transition_matrix() -> Result<(), String> {
     }
 
     // Verify targets exist (weights are internal to Field)
-    if !targets.contains(&to1) {
+    if !targets.contains(&segment_id_from_coords(&to1)) {
         return Err("Target to1 should be in transition targets".to_string());
     }
-    if !targets.contains(&to2) {
+    if !targets.contains(&segment_id_from_coords(&to2)) {
         return Err("Target to2 should be in transition targets".to_string());
     }
 

--- a/poc/standard/crates/field-synthesis/src/lib.rs
+++ b/poc/standard/crates/field-synthesis/src/lib.rs
@@ -12,7 +12,7 @@
 use std::collections::HashSet;
 use std::fmt::Debug;
 
-pub use ssccs_core::{Constraint, Field, Projector, Segment, SpaceCoordinates};
+pub use ssccs_core::{Constraint, Field, Projector, Segment, SegmentId, SpaceCoordinates};
 
 // ==================== COMPOSITION OPERATION ====================
 
@@ -142,23 +142,23 @@ impl ComposedField {
 
     // ---- transitions ----
 
-    pub fn transition_targets(&self, coords: &SpaceCoordinates) -> Vec<SpaceCoordinates> {
+    pub fn transition_targets(&self, coords: &SpaceCoordinates) -> Vec<SegmentId> {
         match self.op {
             CompositionOp::Union => {
                 let mut merged = transition_expr(&self.left, coords);
                 merged.extend(transition_expr(&self.right, coords));
-                merged.sort_by(|a, b| a.raw.cmp(&b.raw));
+                merged.sort();
                 merged.dedup();
                 merged
             }
             CompositionOp::Intersection => {
-                let left: HashSet<SpaceCoordinates> =
+                let left: HashSet<SegmentId> =
                     transition_expr(&self.left, coords).into_iter().collect();
-                let right: HashSet<SpaceCoordinates> =
+                let right: HashSet<SegmentId> =
                     transition_expr(&self.right, coords).into_iter().collect();
-                let mut merged: Vec<SpaceCoordinates> =
+                let mut merged: Vec<SegmentId> =
                     left.intersection(&right).cloned().collect();
-                merged.sort_by(|a, b| a.raw.cmp(&b.raw));
+                merged.sort();
                 merged
             }
             CompositionOp::Product => {
@@ -170,26 +170,11 @@ impl ComposedField {
                 }
                 let left_coords = SpaceCoordinates::new(coords.raw[..axes].to_vec());
                 let right_coords = SpaceCoordinates::new(coords.raw[axes..].to_vec());
-                let left_targets: Vec<SpaceCoordinates> = transition_expr(&self.left, &left_coords)
-                    .into_iter()
-                    .map(|c| {
-                        let mut raw = c.raw;
-                        raw.extend(right_coords.raw.clone());
-                        SpaceCoordinates::new(raw)
-                    })
-                    .collect();
-                let right_targets: Vec<SpaceCoordinates> =
-                    transition_expr(&self.right, &right_coords)
-                        .into_iter()
-                        .map(|c| {
-                            let mut raw = left_coords.raw.clone();
-                            raw.extend(c.raw);
-                            SpaceCoordinates::new(raw)
-                        })
-                        .collect();
+                let left_targets: Vec<SegmentId> = transition_expr(&self.left, &left_coords);
+                let right_targets: Vec<SegmentId> = transition_expr(&self.right, &right_coords);
                 let mut merged = left_targets;
                 merged.extend(right_targets);
-                merged.sort_by(|a, b| a.raw.cmp(&b.raw));
+                merged.sort();
                 merged.dedup();
                 merged
             }
@@ -216,7 +201,7 @@ fn eval_expr(expr: &ComposedExpr, coords: &SpaceCoordinates) -> bool {
     }
 }
 
-fn transition_expr(expr: &ComposedExpr, coords: &SpaceCoordinates) -> Vec<SpaceCoordinates> {
+fn transition_expr(expr: &ComposedExpr, coords: &SpaceCoordinates) -> Vec<SegmentId> {
     match expr {
         ComposedExpr::Field(f) => f.transition_targets(coords),
         ComposedExpr::Identity(_) => Vec::new(),

--- a/poc/standard/crates/field-synthesis/src/lib.rs
+++ b/poc/standard/crates/field-synthesis/src/lib.rs
@@ -156,8 +156,7 @@ impl ComposedField {
                     transition_expr(&self.left, coords).into_iter().collect();
                 let right: HashSet<SegmentId> =
                     transition_expr(&self.right, coords).into_iter().collect();
-                let mut merged: Vec<SegmentId> =
-                    left.intersection(&right).cloned().collect();
+                let mut merged: Vec<SegmentId> = left.intersection(&right).cloned().collect();
                 merged.sort();
                 merged
             }

--- a/poc/standard/crates/field-synthesis/src/main.rs
+++ b/poc/standard/crates/field-synthesis/src/main.rs
@@ -11,7 +11,7 @@
 //!
 //! Adding a scenario requires only implementing the `Scenario` trait and registering it.
 
-use ssccs_core::{Field, Segment, SpaceCoordinates};
+use ssccs_core::{Field, Segment, SpaceCoordinates, segment_id_from_coords};
 use ssccs_examples::{CoordinateSumProjector, EvenConstraint, RangeConstraint};
 use ssccs_field_synthesis::{IdentityField, compose_observe, intersection, product, union};
 
@@ -285,17 +285,17 @@ fn test_transition() {
     assert_eq!(ut.transition_targets(&o).len(), 3);
     let it = intersection(x.clone(), y.clone()).transition_targets(&o);
     assert_eq!(it.len(), 1);
-    assert!(it.contains(&coord(2, 0, 0)));
+    assert!(it.contains(&segment_id_from_coords(&coord(2, 0, 0))));
     println!(
         "  X\u{222A}Y: {:?}",
         ut.transition_targets(&o)
             .iter()
-            .map(|c| &c.raw)
+            .map(|id| id.as_bytes())
             .collect::<Vec<_>>()
     );
     println!(
         "  X\u{2229}Y: {:?}",
-        it.iter().map(|c| &c.raw).collect::<Vec<_>>()
+        it.iter().map(|id| id.as_bytes()).collect::<Vec<_>>()
     );
 }
 


### PR DESCRIPTION
## Summary

Removes the redundant `id_to_coords` HashMap from `TransitionMatrix`, eliminates all legacy coordinate-based methods, and migrates the entire codebase to the `SegmentId`-based API.

### Changes

- **`ssccs-core` (`core.rs`)**:
  - Remove `id_to_coords: HashMap<SegmentId, SpaceCoordinates>` from `TransitionMatrix`
  - Remove legacy methods: `add()`, `transitions_from()`, `get_weight()` (coordinate-based)
  - Rename: `add_by_id()` → `add()`, `transitions_from_id()` → `transitions_from()`, `get_weight_by_id()` → `get_weight()`
  - `Field::transition_targets()` now returns `Vec<SegmentId>`
- **`ssccs-core` (`lib.rs`)**: `possible_next_coordinates()` returns `Vec<SegmentId>`
- **`ssccs-field-synthesis` (`lib.rs`)**: `ComposedField::transition_targets()` updated to work with `SegmentId`
- **Experiment crates**: Updated transition, field, observation tests to use SegmentId-based APIs

### Validation

- `./poc/run.sh --validation --workspace poc/standard` — ALL VALIDATIONS PASSED
  - Formatting ✓
  - Clippy ✓
  - Build ✓
  - Tests ✓
  - Binary crates: 12/12 passed ✓

Closes #41