### PR TITLE
PR: fix(#53): deduplicate entries in _resolve_to_current_paths after path remapping

### DIFF
--- a/docs/_include/_updated_docs_list.qmd
+++ b/docs/_include/_updated_docs_list.qmd
@@ -3,12 +3,12 @@
 
 | Updated | Document |
 |----------|---------|
-| 2026-05-10 | Philosophy > [Structural Observation](/docs/philosophy/epistemology.html) <sup style="background:#2c8;color:#fff;font-size:.65em;padding:0 .4em;border-radius:3px;">N</sup> |
-| 2026-05-07 | Projects > Nexus > Notes > [ACP Ecosystem: Technical Review for Autonomous Research](/docs/projects/nexus/notes/acp_nexus.html) <sup style="background:#2c8;color:#fff;font-size:.65em;padding:0 .4em;border-radius:3px;">N</sup> |
-| 2026-05-07 | Projects > Nexus > Notes > [TokenSpeed Architectural Insights for SSCCS Nexus](/docs/projects/nexus/notes/tokenspeed_insight.html) <sup style="background:#2c8;color:#fff;font-size:.65em;padding:0 .4em;border-radius:3px;">N</sup> |
-| 2026-05-07 | Projects > Nexus > Notes > [QiMeng Insight Analysis & Multi-Agent Autonomous Research Landscape](/docs/projects/nexus/notes/qimeng.html) <sup style="background:#2c8;color:#fff;font-size:.65em;padding:0 .4em;border-radius:3px;">N</sup> |
-| 2026-05-07 | Projects > [HexaField](/docs/index.html) <sup style="background:#2c8;color:#fff;font-size:.65em;padding:0 .4em;border-radius:3px;">N</sup> |
-| 2026-05-10 | Legal > [Charter and Statute](/docs/index.html) |
+| 2026-05-12 | Projects > Nexus > Notes > [QiMeng Insight Analysis & Multi-Agent Autonomous Research Landscape](projects/nexus/notes/qimeng.html) <sup style="background:#2c8;color:#fff;font-size:.65em;padding:0 .4em;border-radius:3px;">N</sup> |
+| 2026-05-12 | Projects > Nexus > Notes > [TokenSpeed Architectural Insights for SSCCS Nexus](projects/nexus/notes/tokenspeed_insight.html) <sup style="background:#2c8;color:#fff;font-size:.65em;padding:0 .4em;border-radius:3px;">N</sup> |
+| 2026-05-11 | Projects > Nexus > Notes > [ACP Ecosystem: Technical Review for Autonomous Research](projects/nexus/notes/acp_nexus.html) <sup style="background:#2c8;color:#fff;font-size:.65em;padding:0 .4em;border-radius:3px;">N</sup> |
+| 2026-05-10 | Philosophy > [Structural Observation](philosophy/epistemology.html) <sup style="background:#2c8;color:#fff;font-size:.65em;padding:0 .4em;border-radius:3px;">N</sup> |
+| 2026-05-12 | Projects > Nexus > [Nexus Architecture](projects/nexus/impl_init.html) |
+| 2026-05-12 | Projects > [Nexus](projects/nexus/index.html) |
 
 
 :::

--- a/docs/_utils/generate_latest_docs.py
+++ b/docs/_utils/generate_latest_docs.py
@@ -241,7 +241,17 @@ def _resolve_to_current_paths(
             cur = fname_to_current.get(Path(path).name)
             if cur is not None:
                 resolved.append((ts, cur))
-    return resolved
+
+    # After remapping old paths to current paths, multiple entries may
+    # resolve to the same current path (e.g. after a rename).  Since
+    # entries are newest-first, keep only the first occurrence per path.
+    seen: set[str] = set()
+    deduped: list[tuple[str, str]] = []
+    for ts, path in resolved:
+        if path not in seen:
+            seen.add(path)
+            deduped.append((ts, path))
+    return deduped
 
 
 def get_tracked_doc_files() -> list[tuple[str, str]]:


### PR DESCRIPTION
When a file is renamed, git log contains commits for both the old path and the current path. `_resolve_to_current_paths` maps both to the same current path, causing duplicate rows in the updated docs table.

Added a deduplication pass after resolution, keeping only the newest entry per resolved path.

Closes #53