### PR TITLE
PR: fix: Pre-build/Post-render success message omits command arguments #56

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -781,7 +781,7 @@ class PreBuildRunner:
                 if result.returncode != 0:
                     logger.warning(f"Pre-build command '{executable}' failed with exit code {result.returncode}, continuing build...")
                 else:
-                    logger.info(f"Pre-build command '{executable}' succeeded.")
+                    logger.info(f"Pre-build command '{' '.join(cmd)}' succeeded.")
             except Exception as e:
                 logger.warning(f"Pre-build command '{executable}' raised an exception: {e}, continuing build...")
 
@@ -849,7 +849,7 @@ class PostRenderRunner:
                 if result.returncode != 0:
                     logger.warning(f"Post-render command '{executable}' failed with exit code {result.returncode}, continuing...")
                 else:
-                    logger.info(f"Post-render command '{executable}' succeeded.")
+                    logger.info(f"Post-render command '{' '.join(cmd)}' succeeded.")
             except Exception as e:
                 logger.warning(f"Post-render command '{executable}' raised an exception: {e}, continuing...")
 


### PR DESCRIPTION
Based on your technical updates for the SSCCS documentation workflow, here is the English translation of your changes for the commit message or technical report:

## **Context**

When executing pre-build or post-render commands defined in `build.yml`, the success message currently displays only the executable name (e.g., `'python3' succeeded.`). This omission of the full command arguments reduces log readability.

**Example of current log for `["python3", "_utils/generate_latest_docs.py"]`:**

> `Pre-build command 'python3' succeeded.`

**Improved log format:**

> `Pre-build command 'python3 _utils/generate_latest_docs.py' succeeded.`

---

## **Changes Made**

* **PreBuildRunner.run()**: Updated the success message to use `' '.join(cmd)` instead of just `executable`.
* **PostRenderRunner.run()**: Applied the same modification to ensure consistent logging across runners.

---

## **Files Changed**

* **docs/build.py**: Modified log messages at lines **L783** and **L851**.

---

**Technical Note:**
It is **imperative** to ensure that all automated processes provide verifiable and transparent logs. Enhancing the visibility of full command arguments is a **crucial** step toward maintaining the **immutable** logic required for high-scale system documentation.