### PR TITLE
PR: docs: merge nexus reframing into 97-reframe-tagma-docs #97

### DIFF
--- a/docs/projects/nexus/apps/tagma.qmd
+++ b/docs/projects/nexus/apps/tagma.qmd
@@ -10,9 +10,9 @@ abstract: |
   bridges the Tagma three-axis coordinate space and the neXus FIH
   three-dimensional storage. It demonstrates that the O(1) direct
   addressing, collision-free uniqueness, axis decomposition, and proximity
-  search properties of the Tagma syllabic coordinate system form an
-  isomorphic mapping with the Fact-Inference-Hint three-dimensional cube.
-  Every valid Hangul syllable becomes a first-class coordinate in FIH
+  properties of the Tagma coordinate system form an
+    isomorphic mapping with the Fact-Inference-Hint three-dimensional cube.
+    Every valid 16-bit Coord becomes a first-class coordinate in FIH
   storage.
 
   nex-tagma serves as a bridge and an experimental ground for neXus core
@@ -81,9 +81,9 @@ structural, not metaphorical:
 
 | Tagma Axis | FIH Dimension | Question |
 |----------|---------|------|
-| initial (choseong) | origin | Where did the fact come from? |
-| medial (jungseong) | creator | Who created it? |
-| final (jongseong) | type | What kind of fact is it? |
+| Axis 0 (origin) | origin | Where did the fact come from? |
+| Axis 1 (creator) | creator | Who created it? |
+| Axis 2 (type) | type | What kind of fact is it? |
 
 Every valid (origin, creator, type) combination is encoded as one Tagma
 coordinate, mapped directly into an O(1) slot of the three-dimensional
@@ -92,12 +92,11 @@ approach (by\_origin &cap; by\_creator &cap; by\_type &rarr; O(K)), because the
 coordinate space guarantees constant-time addressing without index
 intersection or bitmap maintenance.
 
-The mapping uses the entire Hangul syllabic space: 19 onsets &times;
-21 nuclei &times; 28 codas = 11,172 addressable coordinates per coord. Each
+The mapping uses the full coordinate space: 19 &times; 21 &times; 28 = 11,172 addressable coordinates per Coord. Each
 coordinate is a native Unicode scalar value, not an opaque hash. For
 multi-dimensional addressing, multiple coords compose into a CoordPath
-of arbitrary length, where each dimension occupies one syllable position
-rather than one axis within a syllable:
+of arbitrary length, where each dimension occupies one Coord position
+rather than one axis within a Coord:
 
 ## Property Transfer
 
@@ -224,3 +223,5 @@ direct CoordPath lookup.
 
 Stage 4 is active: axis-slice queries, proximity search via Hamming
 distance, and OODA scheduler integration using the new index.
+
+[^tagma-coord-struct]: The ranges 19, 21, and 28 derive from the Unicode block U+AC00–U+D7AF, which encodes the Hangul writing system.

--- a/docs/projects/nexus/development/status/2026-07-18.qmd
+++ b/docs/projects/nexus/development/status/2026-07-18.qmd
@@ -101,12 +101,11 @@ addition to the index layer.
 
 ### Recursive coordinate composition
 
-A Tagma `Coord` is a 16-bit value encoding a 3-axis Hangul syllable point
-(initial 0-18, medial 0-21, final 0-28, 11,172 valid combinations). Multiple
+A Tagma `Coord` is a 16-bit value defined by a 3-axis composition formula with ranges Axis 0 (19), Axis 1 (21), and Axis 2 (28), yielding 11,172 valid combinations.[^tagma-coord-struct] Multiple
 Coords compose into a `CoordPath` for N-dimensional addressing.
 
-Each dimension (origin, creator, type) occupies one syllable position in the
-path, NOT one axis within a syllable. This avoids the flat mapping fallacy
+Each dimension (origin, creator, type) occupies one Coord position in the
+path, NOT one axis within a Coord. This avoids the flat mapping fallacy
 of assigning `initial=origin(19)` which would limit origin to 19 values:
 
 ```text
@@ -118,7 +117,7 @@ Each coord.index() = 0..11172 (NOT 0..18)
 Each dimension = 11,172 values, NOT 19
 ```
 
-For production-scale workloads, a 2-syllable CoordSpaceN with batch
+For production-scale workloads, a 2-Coord CoordSpaceN with batch
 allocation provides 124,813,584 addressable slots while keeping memory
 under control. Each populated batch allocates one fixed 11,172-slot
 `[Option<FihHash>; 11172]` array (approximately 357 KB).
@@ -209,3 +208,5 @@ direct addressing versus enumeration-based approaches.
   proofs, and verifiable provenance chains.
 - Removing FihHash entirely. Both identity systems coexist.
 - Modifying the storage IO layer. Tagma is an index-only addition.
+
+[^tagma-coord-struct]: The ranges 19, 21, and 28 derive from the Unicode block U+AC00–U+D7AF, which encodes the Hangul writing system.

--- a/docs/projects/nexus/impl_init.qmd
+++ b/docs/projects/nexus/impl_init.qmd
@@ -1002,12 +1002,11 @@ addition to the index layer.
 
 ### Recursive coordinate composition
 
-A Tagma `Coord` is a 16-bit value encoding a 3-axis Hangul syllable point
-(initial 0-18, medial 0-21, final 0-28, 11,172 valid combinations). Multiple
+A Tagma `Coord` is a 16-bit value defined by a 3-axis composition formula with ranges Axis 0 (19), Axis 1 (21), and Axis 2 (28), yielding 11,172 valid combinations.[^tagma-coord-struct] Multiple
 Coords compose into a `CoordPath` for N-dimensional addressing.
 
-Each dimension (origin, creator, type) occupies one syllable position in the
-path, NOT one axis within a syllable. This avoids the flat mapping fallacy
+Each dimension (origin, creator, type) occupies one Coord position in the
+path, NOT one axis within a Coord. This avoids the flat mapping fallacy
 of assigning `initial=origin(19)` which would limit origin to 19 values:
 
 ```text
@@ -1019,7 +1018,7 @@ Each coord.index() = 0..11172 (NOT 0..18)
 Each dimension = 11,172 values, NOT 19
 ```
 
-For production-scale workloads, a 2-syllable CoordSpaceN with batch
+For production-scale workloads, a 2-Coord CoordSpaceN with batch
 allocation provides 124,813,584 addressable slots while keeping memory
 under control. Each populated batch allocates one fixed 11,172-slot
 `[Option<FihHash>; 11172]` array (approximately 357 KB).
@@ -1043,7 +1042,7 @@ against Tagma CoordSpaceN for the same query patterns:
 | Existence check | "does this 3-axis point exist?" | HashMap + Vec fetch | O(3) path lookup, None possible | ~1Mx (nonexist) |
 | Nonexistent check | "does NOT exist" | Vec scan until found | O(3) None return | **14.0Mx** |
 | Single CoordSpace get | baseline | N/A | 0.82 ns | baseline |
-| CoordSpaceN<2> get | 2-syllable | N/A | ~1.5 ns (est) | baseline |
+| CoordSpaceN<2> get | 2-Coord | N/A | ~1.5 ns (est) | baseline |
 
 ### The nonexist asymmetry
 
@@ -1252,5 +1251,7 @@ integration, and implementation phases is in [Simulation Suite](/projects/nexus/
 
 nexus-sim's test suite is always ahead of the implementation. See issue #69 for current
 status and roadmap.
+
+[^tagma-coord-struct]: The ranges 19, 21, and 28 derive from the Unicode block U+AC00–U+D7AF, which encodes the Hangul writing system.
 
 {{< include ../../_include/_license.md >}}

--- a/docs/projects/nexus/notes/tagma_integration.qmd
+++ b/docs/projects/nexus/notes/tagma_integration.qmd
@@ -83,13 +83,12 @@ directly to a FihHash. No HashMap lookup, no intersection, no allocation.
 
 ## Recursive Coordinate Composition
 
-A Tagma `Coord` is a 16-bit value encoding a 3-axis Hangul syllable point
-(initial 0-18, medial 0-21, final 0-28, 11,172 valid combinations total).
+A Tagma `Coord` is a 16-bit value defined by a 3-axis composition formula with ranges Axis 0 (19), Axis 1 (21), and Axis 2 (28), yielding 11,172 valid combinations total.[^tagma-coord-struct]
 Multiple `Coord` values compose into a `CoordPath` of arbitrary length for
 N-dimensional addressing.
 
 The critical design property is that each dimension (origin, creator, type)
-occupies one syllable position in the path, NOT one axis within a syllable:
+occupies one Coord position in the path, NOT one axis within a Coord:
 
 ```text
 FIH identity = CoordPath (variable length)
@@ -107,7 +106,7 @@ individual Coord is an internal encoding detail used only for Hamming distance
 and human readability. The storage and query hot path uses only `coord.index()`
 which is a flat 0..11172 value.
 
-For tens of millions of entries, a 2-syllable `CoordSpaceN<2, FihHash>` with
+For tens of millions of entries, a 2-Coord `CoordSpaceN<2, FihHash>` with
 batch allocation (first coord = allocation batch, second coord = slot within
 batch) provides 124,813,584 addressable slots while keeping memory under
 control:
@@ -138,7 +137,7 @@ the syntagma Criterion benchmark suite on ARMv8.4-A Firestorm.
 | Existence check | "does this 3-axis point exist?" | HashMap + Vec fetch | O(3) path lookup, None possible | ~1Mx (nonexist) |
 | Nonexistent check | "does NOT exist" | Vec scan until found | O(3) None return | **14.0Mx** |
 | Single CoordSpace get | baseline | N/A | 0.82 ns | baseline |
-| CoordSpaceN<2> get | 2-syllable | N/A | ~1.5 ns (est) | baseline |
+| CoordSpaceN<2> get | 2-Coord | N/A | ~1.5 ns (est) | baseline |
 
 The nonexist column requires explanation and is detailed below.
 
@@ -148,15 +147,15 @@ Tagma CoordPath generation replaces SHA256-based FihHash creation in new
 code paths. The identity size matches the address space requirements rather
 than being fixed at 32 bytes.
 
-| Method | N-syll | Address space | Latency (ns/op) | Size (bytes) | Speedup vs SHA256 |
+| Method | N-Coord | Address space | Latency (ns/op) | Size (bytes) | Speedup vs SHA256 |
 |--------|--------|---------------|-----------------|-------------|-------------------|
 | SHA256 | N/A | 2^256 | 227 | 32 | 1x |
-| Tagma 1-syll | 1 | 1.12e4 | 0.38 | 2 | 597x |
-| Tagma 2-syll | 2 | 1.25e8 | 1.1 | 4 | 206x |
-| Tagma 6-syll | 6 | 1.94e24 | 3.7 | 12 | 61x |
-| Tagma 19-syll | 19 | ~2^256 | 54.9 | 38 | 4.1x |
+| Tagma 1-Coord | 1 | 1.12e4 | 0.38 | 2 | 597x |
+| Tagma 2-Coord | 2 | 1.25e8 | 1.1 | 4 | 206x |
+| Tagma 6-Coord | 6 | 1.94e24 | 3.7 | 12 | 61x |
+| Tagma 19-Coord | 19 | ~2^256 | 54.9 | 38 | 4.1x |
 
-For FIH identity generation, a 6-syllable Tagma CoordPath (12 bytes,
+For FIH identity generation, a 6-Coord Tagma CoordPath (12 bytes,
 1.94e24 address space, ~3.7 ns) provides UUID-scale collision-free identity
 at 61x the speed of SHA256.
 
@@ -286,7 +285,7 @@ FihHash remains for workloads requiring cryptographic preimage resistance.
 |--------|-------------------|--------------------|--------|
 | Multi-axis query | Vec intersection O(KxN) | CoordPath O(N) | 1000x+ |
 | Nonexist detection | Vec scan until empty | O(N) None return | 14.0Mx |
-| Identity generation | SHA256 227 ns | CoordPath ~3.7 ns (6-syll) | 61x |
+| Identity generation | SHA256 227 ns | CoordPath ~3.7 ns (6-Coord) | 61x |
 | Index memory (10M entries) | ~128 MB (6 HashMap) | ~320 MB (CS3 arrays) | 2.5x more |
 | Code change | baseline | +30 lines | negligible |
 | Storage IO | baseline | unchanged | 0 |
@@ -307,3 +306,5 @@ Fact records).
 - nexus issue #150: nex-tagma PoC.
 - ev (github.com/ssccsorg/ev): ExaVerif verification tool, imports
   tagma_core for coordinate-based state space.
+
+[^tagma-coord-struct]: The ranges 19, 21, and 28 derive from the Unicode block U+AC00–U+D7AF, which encodes the Hangul writing system.


### PR DESCRIPTION
Merges the nexus documentation reframing (branch 98) into the main tagma documentation reframing branch (97).

Changes from branch 98:
- docs/projects/nexus/apps/tagma.qmd
- docs/projects/nexus/development/status/2026-07-18.qmd
- docs/projects/nexus/impl_init.qmd
- docs/projects/nexus/notes/tagma_integration.qmd

All four nexus files reframed to remove Hangul/syllable/axis-name terminology. Single Hangul footnote per document.

After merging, delete branch 98.