### PR TITLE
PR: refactor: make raw asm the single assembly source and verify all modules under Spike #109

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ _agent/
 _pages/
 _jupyter_cache/
 poc/baremetal_riscv/simulation/spike_test
+poc/baremetal_riscv/simulation/asm_modules_test
 poc/baremetal_riscv/simulation/concept*
 !poc/baremetal_riscv/simulation/concept*.c
 !poc/baremetal_riscv/simulation/concept*.S

--- a/poc/README.md
+++ b/poc/README.md
@@ -24,7 +24,7 @@ poc/
 │   └── run.sh              Benchmark runner: verify + kernels, results in result/
 │
 ├── baremetal_riscv/        RISC-V integration crate
-│   ├── Cargo.toml          Host build; riscv32 inline asm, RV64 assembly under Spike
+│   ├── Cargo.toml          Host build; custom instruction encodings, RV64 assembly under Spike
 │   ├── asm/                Five hand-written .S modules (observation pipeline)
 │   ├── src/                Custom instruction encodings, emulation, golden anchor tests
 │   ├── simulation/         C concept programs 01-11 plus Spike + riscv-pk harness

--- a/poc/README.md
+++ b/poc/README.md
@@ -171,7 +171,7 @@ Generated gates follow `fn(*const i64) -> u32`: coordinate pointer in `a0`, gate
 
 - 19 golden anchors cross-verified across RISC-V assembly, SystemVerilog, and the Rust fallback, with `ev` (ExaVerif) as an independent fourth channel.
 - Determinism and race-free concurrent observation tests in `ssccs-examples/tests/`.
-- Assembly syntax gate over all `asm/*.S`, C concept programs 01-11 executed under Spike + pk in `simulation/`, and Verilator SystemVerilog checks in `sv/`.
+- Assembly syntax gate over all `asm/*.S`; every module also executes under Spike + pk in `simulation/` (`observe_full.S` via `spike_test.c` and the concept harnesses, the remaining four via `asm_modules_test.c`); Verilator SystemVerilog checks in `sv/`.
 - Benchmark kernels in `benches/` (run `benches/run.sh` manually; not part of the default validation or CI): the measured emulation overhead on existing hardware informs the practical plane; it never shapes the model.
 
 ## License

--- a/poc/baremetal_riscv/README.md
+++ b/poc/baremetal_riscv/README.md
@@ -50,7 +50,7 @@ This crate has two distinct paths with different target requirements:
 | Path | Target | Status |
 |------|--------|--------|
 | Rust fallback | Host (x86_64 / aarch64) | Default `cargo test` / `cargo build`, golden anchors verified |
-| RISC-V assembly | RV64 (`riscv64-unknown-elf-*` toolchain) | Assembled and executed under Spike + pk (`simulation/run.sh`), plus a syntax gate over all `asm/*.S` |
+| RISC-V assembly | RV64 (`riscv64-unknown-elf-*` toolchain) | All five `asm/*.S` modules assembled and executed under Spike + pk (`simulation/run.sh`): `observe_full.S` via `spike_test.c` and the concept harnesses, the other four via `asm_modules_test.c`; plus a syntax gate over all `asm/*.S` |
 | Bare-metal cargo build | `riscv32imac-unknown-none-elf` | Blocked: the standard workspace crates (`ssccs-core`, `ssccs-primitive`) depend on std-only crates (`hex`, `serde` default, `thiserror`, `blake3` default). Tracked as a follow-up no_std refactor |
 
 The assembly modules use RV64 instructions (`ld`/`sd`/`.8byte`). The reference simulation executes the assembly path at the ISA level via Spike, and the host path validates the same golden anchors through the Rust fallback.

--- a/poc/baremetal_riscv/build.rs
+++ b/poc/baremetal_riscv/build.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 /// Parse a single assembly file and return its module name and a list of constant declarations.
 fn parse_asm_file(path: &Path) -> (String, Vec<String>) {
-    let content = fs::read_to_string(path).expect(&format!("can't read {:?}", path));
+    let content = fs::read_to_string(path).unwrap_or_else(|_| panic!("can't read {:?}", path));
     let stem = path.file_stem().unwrap().to_str().unwrap().to_string();
     let mut consts = Vec::new();
 
@@ -20,7 +20,6 @@ fn parse_asm_file(path: &Path) -> (String, Vec<String>) {
             .strip_prefix(".globl ")
             .map(|g| g.split(';').next().unwrap_or(g))
             .unwrap_or(bef)
-            .trim()
             .split_whitespace()
             .last()
             .unwrap_or("");

--- a/poc/baremetal_riscv/simulation/asm_modules_test.c
+++ b/poc/baremetal_riscv/simulation/asm_modules_test.c
@@ -1,0 +1,223 @@
+/*
+ * SSCCS Spike Runtime Validation — Collapse, Field, Layout, Adjacency
+ *
+ * Calls the assembly modules collapse.S, field_update.S, scheme_layout.S,
+ * and scheme_adjacency.S under Spike + pk, and validates their outputs
+ * against the golden anchors documented in each .S file.
+ *
+ * This is the runtime complement of the assembly syntax gate: the gate
+ * proves every module assembles, this harness proves the modules execute
+ * correctly on the ISA.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+/* ── collapse.S ── */
+extern long long collapse_sum(long long *coords, long long count);
+extern long long collapse_min(long long *coords, long long count);
+extern long long collapse_max(long long *coords, long long count);
+extern long long collapse_product(long long *coords, long long count);
+extern long long collapse_count(long long *results, long long count, long long sentinel);
+extern long long collapse_weighted_sum(long long *coords, long long *weights, long long count);
+extern long long collapse_weighted_avg(long long *coords, long long *weights, long long count);
+extern long long collapse(long long *coords, long long count,
+                          long long (*reducer)(long long *, long long));
+
+/* ── field_update.S ──
+ * Field state layout expected by the assembly primitives:
+ *   offset 0:   constraint_fn_ptrs[8]
+ *   offset 64:  constraint_ids[8] (u32)
+ *   offset 96:  transitions[16] of {from, to, weight} (24 bytes each)
+ *   offset 480: num_constraints (u32)
+ *   offset 484: num_transitions (u32)
+ */
+typedef struct {
+    unsigned long long constraint_fns[8];
+    unsigned int constraint_ids[8];
+    struct {
+        long long from;
+        long long to;
+        long long weight;
+    } transitions[16];
+    unsigned int num_constraints;
+    unsigned int num_transitions;
+} FieldState;
+
+extern long long field_add_constraint(FieldState *f, unsigned long long fn, unsigned int id);
+extern long long field_remove_constraint(FieldState *f, unsigned int id);
+extern void field_clear(FieldState *f);
+extern long long field_add_transition(FieldState *f, long long from, long long to,
+                                      long long weight);
+extern long long field_update_weight(FieldState *f, long long from, long long to,
+                                     long long weight);
+extern long long field_get_transitions(FieldState *f, long long from, long long *out);
+
+/* ── scheme_layout.S ── */
+extern long long layout_linear_1d(long long coord, long long stride);
+extern long long layout_linear_nd(long long *coords, long long *strides, unsigned int dims);
+extern long long layout_row_major_2d(long long x, long long y, long long width,
+                                     long long elem_size);
+extern long long layout_row_major_3d(long long x, long long y, long long z,
+                                     long long width, long long height,
+                                     long long elem_size);
+extern long long layout_col_major_2d(long long x, long long y, long long height,
+                                     long long elem_size);
+extern long long morton_encode_2d(long long x, long long y);
+extern long long layout_zorder_2d(long long x, long long y, long long elem_size);
+
+/* ── scheme_adjacency.S ── */
+extern long long adj_grid_4(long long x, long long y, long long min_x, long long max_x,
+                            long long min_y, long long max_y, long long *out);
+extern long long adj_grid_8(long long x, long long y, long long min_x, long long max_x,
+                            long long min_y, long long max_y, long long *out);
+extern long long adj_manhattan_1d(long long coord, long long dist, long long min_coord,
+                                  long long max_coord, long long *out);
+extern long long adj_graph_edges(long long *edge_pairs, long long num_edges,
+                                 long long from_id, long long *out);
+
+/* observe_full.S emits this sentinel for rejected observations. */
+#define REJECT_SENTINEL (0x8000000000000000LL)
+
+static int total_passed = 0;
+static int total_failed = 0;
+
+#define TEST(name, cond, expected, actual)                              \
+    do {                                                                \
+        long long exp_ = (long long)(expected);                         \
+        long long act_ = (long long)(actual);                           \
+        if ((cond)) {                                                   \
+            printf("PASS: %s\n", (name));                              \
+            total_passed++;                                             \
+        } else {                                                        \
+            printf("FAIL: %s (expected %lld, got %lld)\n",             \
+                   (name), exp_, act_);                                 \
+            total_failed++;                                             \
+        }                                                               \
+    } while (0)
+
+static unsigned int dummy_constraint(long long *c)
+{
+    (void)c;
+    return 1;
+}
+
+int main(void)
+{
+    long long r;
+
+    printf("-- collapse --\n");
+    {
+        long long a[4] = {2, 4, 6, 8};
+        long long b[4] = {1, 3, 5, 7};
+        long long w_a[4] = {1, 2, 1, 2};
+        long long results[4] = {2, REJECT_SENTINEL, REJECT_SENTINEL, 10};
+
+        r = collapse_sum(a, 4);
+        TEST("collapse_sum(A)", r == 20, 20, r);
+        r = collapse_sum(b, 4);
+        TEST("collapse_sum(B)", r == 16, 16, r);
+        r = collapse_min(a, 4);
+        TEST("collapse_min(A)", r == 2, 2, r);
+        r = collapse_max(b, 4);
+        TEST("collapse_max(B)", r == 7, 7, r);
+        r = collapse_product(a, 4);
+        TEST("collapse_product(A)", r == 384, 384, r);
+        r = collapse_count(results, 4, REJECT_SENTINEL);
+        TEST("collapse_count", r == 2, 2, r);
+        r = collapse_weighted_sum(a, w_a, 4);
+        TEST("collapse_weighted_sum(A)", r == 32, 32, r);
+        r = collapse_weighted_avg(a, w_a, 4);
+        TEST("collapse_weighted_avg(A)", r == 5, 5, r);
+        r = collapse(a, 4, collapse_sum);
+        TEST("collapse(sum, A)", r == 20, 20, r);
+    }
+
+    printf("\n-- field update --\n");
+    {
+        FieldState fs = {0};
+        unsigned long long fn = (unsigned long long)(uintptr_t)dummy_constraint;
+
+        r = field_add_constraint(&fs, fn, 7);
+        TEST("field_add_constraint", r == 0, 0, r);
+        TEST("num_constraints", fs.num_constraints == 1, 1, fs.num_constraints);
+        r = field_add_constraint(&fs, fn, 8);
+        TEST("field_add_constraint#2", r == 0, 0, r);
+        r = field_remove_constraint(&fs, 7);
+        TEST("field_remove_constraint", r == 0, 0, r);
+        TEST("num_constraints after remove", fs.num_constraints == 1, 1,
+             fs.num_constraints);
+        field_clear(&fs);
+        TEST("field_clear", fs.num_constraints == 0, 0, fs.num_constraints);
+
+        r = field_add_transition(&fs, 1, 2, 10);
+        TEST("field_add_transition", r == 0, 0, r);
+        r = field_update_weight(&fs, 1, 2, 99);
+        TEST("field_update_weight", r == 0, 0, r);
+        r = field_update_weight(&fs, 9, 2, 1);
+        TEST("field_update_weight(miss)", r == -1, -1, r);
+        {
+            long long out[32] = {0};
+            r = field_get_transitions(&fs, 1, out);
+            TEST("field_get_transitions count", r == 1, 1, r);
+            TEST("field_get_transitions to", out[0] == 2, 2, out[0]);
+            TEST("field_get_transitions weight", out[1] == 99, 99, out[1]);
+        }
+    }
+
+    printf("\n-- scheme layout --\n");
+    {
+        long long coords[2] = {1, 2};
+        long long strides[2] = {10, 20};
+
+        r = layout_linear_1d(6, 7);
+        TEST("layout_linear_1d", r == 42, 42, r);
+        r = layout_linear_nd(coords, strides, 2);
+        TEST("layout_linear_nd", r == 50, 50, r);
+        r = layout_row_major_2d(2, 5, 8, 1);
+        TEST("layout_row_major_2d", r == 42, 42, r);
+        r = layout_row_major_3d(1, 2, 3, 4, 5, 2);
+        TEST("layout_row_major_3d", r == 138, 138, r);
+        r = layout_col_major_2d(3, 4, 10, 1);
+        TEST("layout_col_major_2d", r == 34, 34, r);
+        r = morton_encode_2d(1, 2);
+        TEST("morton_encode_2d", r == 9, 9, r);
+        r = layout_zorder_2d(1, 2, 1);
+        TEST("layout_zorder_2d", r == 9, 9, r);
+    }
+
+    printf("\n-- scheme adjacency --\n");
+    {
+        long long out[16] = {0};
+        r = adj_grid_4(2, 2, 0, 4, 0, 4, out);
+        TEST("adj_grid_4(center)", r == 4, 4, r);
+        r = adj_grid_4(0, 0, 0, 4, 0, 4, out);
+        TEST("adj_grid_4(corner)", r == 2, 2, r);
+        r = adj_grid_8(2, 2, 0, 4, 0, 4, out);
+        TEST("adj_grid_8(center)", r == 8, 8, r);
+        r = adj_grid_8(0, 0, 0, 4, 0, 4, out);
+        TEST("adj_grid_8(corner)", r == 3, 3, r);
+    }
+    {
+        long long out[8] = {0};
+        r = adj_manhattan_1d(5, 1, 0, 10, out);
+        TEST("adj_manhattan_1d(d1)", r == 2, 2, r);
+        r = adj_manhattan_1d(5, 2, 0, 10, out);
+        TEST("adj_manhattan_1d(d2)", r == 4, 4, r);
+    }
+    {
+        long long edges[6] = {1, 2, 1, 3, 2, 4};
+        long long out[8] = {0};
+        r = adj_graph_edges(edges, 3, 1, out);
+        TEST("adj_graph_edges count", r == 2, 2, r);
+        TEST("adj_graph_edges to0", out[0] == 2, 2, out[0]);
+        TEST("adj_graph_edges to1", out[1] == 3, 3, out[1]);
+    }
+
+    printf("\n=== SUMMARY ===\n");
+    printf("Passed: %d\n", total_passed);
+    printf("Failed: %d\n", total_failed);
+    printf("Total:  %d\n", total_passed + total_failed);
+
+    return total_failed > 0 ? 1 : 0;
+}

--- a/poc/baremetal_riscv/simulation/run.sh
+++ b/poc/baremetal_riscv/simulation/run.sh
@@ -114,7 +114,24 @@ done
 echo "Building legacy test..."
 $CC -static -Wall -Wextra -O0 -g -o "$TARGET" "$TEST_C" "$STUBS_C" "$ASM_S"
 echo "  -> $TARGET"
-echo ""
+
+# ── Build asm module test (collapse/field/layout/adjacency under Spike) ──
+# The remaining .S modules are executed here, not just syntax-gated, so every
+# assembly module runs on the ISA as well as assembling cleanly.
+ASM_MOD_TEST_C="$SCRIPT_DIR/asm_modules_test.c"
+ASM_MOD_BIN="$SCRIPT_DIR/asm_modules_test"
+if [ -f "$ASM_MOD_TEST_C" ]; then
+    echo "Building asm module test..."
+    if $CC -static -Wall -Wextra -O0 -g -o "$ASM_MOD_BIN" "$ASM_MOD_TEST_C" "$STUBS_C" \
+        "$ASMDIR/collapse.S" "$ASMDIR/field_update.S" \
+        "$ASMDIR/scheme_layout.S" "$ASMDIR/scheme_adjacency.S"; then
+        echo "  -> $ASM_MOD_BIN"
+    else
+        echo "  !! asm module test build failed"
+        ASM_MOD_BIN=""
+    fi
+    echo ""
+fi
 
 # ── Run all binaries under Spike ─────────────────────────────
 run_all() {
@@ -138,6 +155,7 @@ run_all() {
 }
 
 TARGETS="$EXP_TARGETS $TARGET"
+[ -n "$ASM_MOD_BIN" ] && TARGETS="$TARGETS $ASM_MOD_BIN"
 case "$MODE" in
     run)
         echo "Running under Spike..."

--- a/poc/baremetal_riscv/src/instructions/mod.rs
+++ b/poc/baremetal_riscv/src/instructions/mod.rs
@@ -87,57 +87,14 @@ pub fn decode_custom(inst: u32) -> (u8, u8, u8, u8, u8) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// Inline assembly wrappers (riscv32 only)
-// ═══════════════════════════════════════════════════════════════════════
-
-/// OBSERVE: single observation (custom1, funct3=000).
-#[cfg(target_arch = "riscv32")]
-pub unsafe fn observe(scheme_id: u32, field_id: u32, rule_id: u32) -> u32 {
-    let result: u32;
-    core::arch::asm!(
-        "custom1 {res}, {s}, {f}, {r}, 0",
-        s = in(reg) scheme_id,
-        f = in(reg) field_id,
-        r = in(reg) rule_id,
-        res = out(reg) result,
-        options(nostack, preserves_flags)
-    );
-    result
-}
-
-/// COLLAPSE: multi-segment reduction (custom2, funct3=001).
-#[cfg(target_arch = "riscv32")]
-pub unsafe fn collapse(coords_ptr: u32, count: u32, reducer_fn: u32) -> u32 {
-    let result: u32;
-    core::arch::asm!(
-        "custom2 {res}, {c}, {n}, {r}, 1",
-        c = in(reg) coords_ptr,
-        n = in(reg) count,
-        r = in(reg) reducer_fn,
-        res = out(reg) result,
-        options(nostack)
-    );
-    result
-}
-
-/// FIELD_UPDATE: modify field state (custom2, funct3=010).
-#[cfg(target_arch = "riscv32")]
-pub unsafe fn field_update(field_ptr: u32, op: u32, arg: u32) -> u32 {
-    let result: u32;
-    core::arch::asm!(
-        "custom2 {res}, {f}, {o}, {a}, 2",
-        f = in(reg) field_ptr,
-        o = in(reg) op,
-        a = in(reg) arg,
-        res = out(reg) result,
-        options(nostack)
-    );
-    result
-}
-
-// ═══════════════════════════════════════════════════════════════════════
 // Software emulation (all platforms)
 // ═══════════════════════════════════════════════════════════════════════
+
+// The canonical assembly implementation lives in the raw `asm/*.S` modules
+// (RV64, executed under Spike and pinned by golden anchors). This module
+// intentionally carries no inline assembly: the Rust side only defines the
+// custom instruction encodings above and the host-verifiable software
+// emulation below, so RTL conversion has a single assembly substrate to read.
 
 /// Software emulation of OBSERVE.
 pub fn observe_emulate(scheme_id: u32, field_id: u32, rule_id: u32) -> u32 {


### PR DESCRIPTION
## Summary

Makes the raw RISC-V assembly modules (`poc/baremetal_riscv/asm/*.S`) the single assembly source of truth, so RTL conversion has one substrate to read, and brings every module into the runtime validation flow.

Closes #109.

## Changes

- `src/instructions/mod.rs`: removed the `core::arch::asm!` wrappers (`observe`, `collapse`, `field_update`). Kept the instruction encodings (`encode_custom_rtype`, `decode_custom`, opcode/funct3/op constants) and the host-verifiable software emulation. Module docs now state that `asm/*.S` is the canonical assembly source.
- `build.rs`: cleaned two pre-existing clippy lints (`expect_fun_call`, `trim_split_whitespace`).
- `simulation/asm_modules_test.c` (new): C harness that executes `collapse.S`, `field_update.S`, `scheme_layout.S`, and `scheme_adjacency.S` under Spike + pk, validating against their golden anchors (37 checks).
- `simulation/run.sh`: builds and runs the new harness under Spike alongside `spike_test.c` and the concept programs; restored the missing executable bit.
- `README.md` (root poc + baremetal): validation evidence and Target Reality updated to reflect that all five `asm/*.S` modules now execute on the ISA.
- `.gitignore`: ignore the `asm_modules_test` binary.

## Validation

`bash poc/baremetal_riscv/run.sh --check` on this machine:

```
Layer 0: Assembly syntax gate     5/5 PASSED
Layer 1: Spike (36 + 37 checks)   PASSED
Layer 2: SystemVerilog bridge     PASSED
Results: 3 passed, 0 failed
```

`cargo test` in `baremetal_riscv` (21 tests incl. golden anchors) and `cargo fmt --check` pass on host.

Harness bug found and fixed during development: `morton_encode_2d(2,1)` is 6, not 9; the golden anchor 9 corresponds to `(1,2)`, matching the Rust fallback.